### PR TITLE
fixed #10 ; added `make cov` and reverted the change of #9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ jobs:
       - image: buildpack-deps:18.04
     steps:
       - checkout
-      - run: CXXFLAGS='-coverage' CFLAGS='-coverage' LDFLAGS='-coverage' sh ./build.sh -s test
-      - run: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+      - run: sh ./build.sh -s cov
+      - run: bash <(curl -s https://codecov.io/bash) -X gcov || echo "Codecov did not collect coverage reports"
 workflows:
   version: 2
   build_and_test:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ all: build lib
 include .project.mk
 
 DEFAULT_CFLAGS ?=
-DEFAULT_CFLAGS += -MMD -MD
+DEFAULT_CFLAGS += -MMD
 DEFAULT_CFLAGS += -pedantic-errors -Wall -Wpedantic -Wextra
 DEFAULT_CFLAGS += -Winit-self -Wno-missing-field-initializers
 
@@ -43,7 +43,14 @@ test: $(TARGET)
 
 clean:
 	@rm -f $(TARGET) $(TARGET).exe $(LIBTARGET) $(OBJS) $(DEPS) $(COVS) *~
+	@rm -f *.gcov
 	@rm -df obj bin lib
+
+cov: CFLAGS   += -coverage
+cov: CXXFLAGS += -coverage
+cov: LDFLAGS  += -coverage
+cov: all test
+	@gcov -abcpru -o obj $(SRCS)
 
 $(TARGET): $(OBJS)
 	$(info [LD]    Build   : $@	[$(notdir $(CURDIR))])
@@ -58,16 +65,16 @@ $(LIBTARGET): $(LIBOBJS)
 obj/%.o: src/%.c
 	$(info [C]     Compile : $@ ($<))
 	@mkdir -p $(dir $@)
-	@$(CC) $(CFLAGS) -c -o $@ $(realpath $<)
+	@$(CC) $(CFLAGS) -c -o $@ $<
 
 obj/%.o: src/%.cpp
 	$(info [C++]   Compile : $@ ($<))
 	@mkdir -p $(dir $@)
-	@$(CXX) $(CXXFLAGS) -c -o $@ $(realpath $<)
+	@$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 obj/%.o: src/%.cxx
 	$(info [C++]   Compile : $@ ($<))
 	@mkdir -p $(dir $@)
-	@$(CXX) $(CXXFLAGS) -c -o $@ $(realpath $<)
+	@$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 -include $(DEPS)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,5 @@
 # -*- coding:utf-8-unix -*-
-.PHONY: all build clean lib test
+.PHONY: all build clean cov lib test
 
 all: build lib
 


### PR DESCRIPTION
- a relative path to source file is passed to C/C++ compiler
- `make cov` runs `gcov` instead of CodeCov
- disabled that CodeCov's `gcov` step
- CodeCov reports the result of `make cov`