### PR TITLE
refactor: generic `seq(p,...)`

### DIFF
--- a/include/cparsec2.h
+++ b/include/cparsec2.h
@@ -276,11 +276,21 @@ PARSER(List(String)) MANY1(String)(PARSER(String) p);
 PARSER(List(Int)) MANY1(Int)(PARSER(Int) p);
 
 // Parser<T[]> seq(Parser<T> p, ...);
-#define seq(...) SEQ_I(__VA_ARGS__, NULL)
-#define SEQ_I(p, ...)                                                    \
-  _Generic((p), PARSER(Char) : seq_char)((PARSER(Char)[]){p, __VA_ARGS__})
+#define SEQ(T) CAT(seq_, T)
 
-PARSER(String) seq_char(PARSER(Char) ps[]);
+#define seq(...) SEQ_0(__VA_ARGS__, NULL)
+// clang-format off
+#define SEQ_0(p, ...)                               \
+  _Generic((p)                                      \
+           , PARSER(Char)   : SEQ(Char)             \
+           , PARSER(String) : SEQ(String)           \
+           , PARSER(Int)    : SEQ(Int)              \
+           )((void*[]){p, __VA_ARGS__})
+// clang-format on
+
+PARSER(List(Char)) SEQ(Char)(void* ps[]);
+PARSER(List(String)) SEQ(String)(void* ps[]);
+PARSER(List(Int)) SEQ(Int)(void* ps[]);
 
 // Parser<T[]> cons(Parser<T> p, Parser<T[]> ps);
 #define cons(p, ps) _Generic((p), PARSER(Char) : cons_char)(p, ps)

--- a/include/cparsec2.hpp
+++ b/include/cparsec2.hpp
@@ -90,13 +90,20 @@ inline PARSER(List(Int)) many1(PARSER(Int) p) {
 #ifdef seq
 #undef seq
 template <typename... Parser>
-inline PARSER(String) seq(PARSER(Char) p, Parser... args) {
+inline PARSER(List(Char)) seq(PARSER(Char) p, Parser... args) {
   PARSER(Char) ps[] = {p, args..., NULL};
-  return seq_char(ps);
+  return SEQ(Char)((void**)ps);
 }
-#endif
-#ifdef SEQ_I
-#undef SEQ_I
+template <typename... Parser>
+inline PARSER(List(String)) seq(PARSER(String) p, Parser... args) {
+  PARSER(String) ps[] = {p, args..., NULL};
+  return SEQ(String)((void**)ps);
+}
+template <typename... Parser>
+inline PARSER(List(Int)) seq(PARSER(Int) p, Parser... args) {
+  PARSER(Int) ps[] = {p, args..., NULL};
+  return SEQ(Int)((void**)ps);
+}
 #endif
 
 #ifdef cons

--- a/test/src/test_seq.cpp
+++ b/test/src/test_seq.cpp
@@ -32,3 +32,30 @@ SCENARIO("seq(letter, digit, digit)", "[cparsec2][parser][seq]") {
   }
   cparsec2_end();
 }
+
+SCENARIO("seq", "[cparsec2][parser][seq]") {
+  cparsec2_init();
+  GIVEN("an input \"123 456 789\"") {
+    Source src = Source_new("123 456 789");
+    WHEN("apply seq(number, number, number)") {
+      List(Int) xs = parse(seq(number, number, number), src);
+      THEN("reaults [123, 456, 789]") {
+        int* itr = list_begin(xs);
+        REQUIRE(123 == itr[0]);
+        REQUIRE(456 == itr[1]);
+        REQUIRE(789 == itr[2]);
+      }
+    }
+    WHEN("apply seq(x, x, x), where x = token(many1(digit))") {
+      PARSER(String) x = token(many1(digit));
+      List(String) xs = parse(seq(x, x, x), src);
+      THEN("results [\"123\", \"456\", \"789\"]") {
+        const char** itr = list_begin(xs);
+        REQUIRE("123" == std::string(itr[0]));
+        REQUIRE("456" == std::string(itr[1]));
+        REQUIRE("789" == std::string(itr[2]));
+      }
+    }
+  }
+  cparsec2_end();
+}


### PR DESCRIPTION
(relative to #28 )
- PARSER(List(Char)) seq(PARSER(Char) p, ...)
- PARSER(List(String)) seq(PARSER(String) p, ...)
- PARSER(List(Int)) seq(PARSER(Int) p, ...)