### PR TITLE
fixed parser-combinators should support PARSER(List(T))

### DIFF
--- a/docs/API.org
+++ b/docs/API.org
@@ -347,8 +347,10 @@ For example:
   - if ~p1~ success and then ~p2~ failed, throws error of ~p2~.
   - *NOTE* : ~S~ and ~T~ must be one of the following:
     - ~Char~
-    - ~String~
+    - ~String~ aka ~List(Char)~
     - ~Int~
+    - ~List(String)~
+    - ~List(Int)~
   - *NOTE* : ~S~ and ~T~ may or may not be same.\\
     (i.e. ~p1~ and ~p2~ may be a parser of same type or different type)
 
@@ -373,8 +375,10 @@ parseTest(skip1st(string1("ab"), char1('c')), "abc"); // -> 'c'
   - return the result of ~p~.
   - *NOTE* : ~T~ must be one of the following:
     - ~Char~
-    - ~String~
+    - ~String~ aka ~List(Char)~
     - ~Int~
+    - ~List(String)~
+    - ~List(Int)~
 
 *** either(p1, p2)
 - PARSER(Char) either(char c1, char c2) :: 
@@ -398,8 +402,10 @@ parseTest(skip1st(string1("ab"), char1('c')), "abc"); // -> 'c'
   - throw error of ~p2~
   - *NOTE* : ~T~ must be one of the following:
     - ~Char~
-    - ~String~
+    - ~String~ aka ~List(Char)~
     - ~Int~
+    - ~List(String)~
+    - ~List(Int)~
 
 *** tryp(p)
 - PARSER(Char) tryp(char c) ::
@@ -413,8 +419,10 @@ parseTest(skip1st(string1("ab"), char1('c')), "abc"); // -> 'c'
   - otherwise rewind the input-state back then throw error of ~p~.
   - *NOTE* : ~T~ must be one of the following:
     - ~Char~
-    - ~String~
+    - ~String~ aka ~List(Char)~
     - ~Int~
+    - ~List(String)~
+    - ~List(Int)~
 
 
 * Building block of Parser-class

--- a/include/cparsec2.h
+++ b/include/cparsec2.h
@@ -146,15 +146,17 @@ void consume(Source src);
   void SHOW(T)(R x)
 
 // clang-format off
-#define PARSER_CAST(x)                                \
-    _Generic((x)                                      \
-             , char           : char1                 \
-             , char*          : string1               \
-             , const char*    : string1               \
-             , PARSER(Char)   : PARSER_ID_FN(Char)    \
-             , PARSER(String) : PARSER_ID_FN(String)  \
-             , PARSER(Int)    : PARSER_ID_FN(Int)     \
-             )(x)
+#define PARSER_CAST(x)                                          \
+  _Generic((x)                                                  \
+           , char                 : char1                       \
+           , char*                : string1                     \
+           , const char*          : string1                     \
+           , PARSER(Char)         : PARSER_ID_FN(Char)          \
+           , PARSER(String)       : PARSER_ID_FN(String)        \
+           , PARSER(Int)          : PARSER_ID_FN(Int)           \
+           , PARSER(List(String)) : PARSER_ID_FN(List(String))  \
+           , PARSER(List(Int))    : PARSER_ID_FN(List(Int))     \
+           )(x)
 // clang-format on
 
 // ---- CharParser ----
@@ -220,32 +222,45 @@ PARSER(Char) expects(const char* desc, PARSER(Char) p); // TODO test
 // Parser<Int> skip(Parser<T> p);
 #define SKIP(T) CAT(skip_, T)
 // clang-format off
-#define skip(p)                                 \
-  _Generic((PARSER_CAST(p))                     \
-           , PARSER(Char)   : SKIP(Char)        \
-           , PARSER(String) : SKIP(String)      \
-           , PARSER(Int)    : SKIP(Int)         \
+#define skip(p)                                         \
+  _Generic((PARSER_CAST(p))                             \
+           , PARSER(Char)         : SKIP(Char)          \
+           , PARSER(String)       : SKIP(String)        \
+           , PARSER(Int)          : SKIP(Int)           \
+           , PARSER(List(String)) : SKIP(List(String))  \
+           , PARSER(List(Int))    : SKIP(List(Int))     \
            )(PARSER_CAST(p))
 // clang-format on
 
-PARSER(Int) SKIP(Char)(PARSER(Char) p);
-PARSER(Int) SKIP(String)(PARSER(String) p);
-PARSER(Int) SKIP(Int)(PARSER(Int) p);
+#define DECLARE_SKIP(T) PARSER(Int) SKIP(T)(PARSER(T) p)
+
+DECLARE_SKIP(Char);
+DECLARE_SKIP(String);
+DECLARE_SKIP(Int);
+DECLARE_SKIP(List(String));
+DECLARE_SKIP(List(Int));
 
 // Parser<T2> skip1st(Parser<T1> p1, Parser<T2> p2);
 #define SKIP1ST(T) CAT(skip1st_, T)
 // clang-format off
-#define skip1st(p1, p2)                         \
-  _Generic((PARSER_CAST(p2))                    \
-           , PARSER(Char)   : SKIP1ST(Char)     \
-           , PARSER(String) : SKIP1ST(String)   \
-           , PARSER(Int)    : SKIP1ST(Int)      \
+#define skip1st(p1, p2)                                    \
+  _Generic((PARSER_CAST(p2))                               \
+           , PARSER(Char)         : SKIP1ST(Char)          \
+           , PARSER(String)       : SKIP1ST(String)        \
+           , PARSER(Int)          : SKIP1ST(Int)           \
+           , PARSER(List(String)) : SKIP1ST(List(String))  \
+           , PARSER(List(Int))    : SKIP1ST(List(Int))     \
            )(skip(p1), (PARSER_CAST(p2)))
 // clang-format on
 
-PARSER(Char) SKIP1ST(Char)(PARSER(Int) p1, PARSER(Char) p2);
-PARSER(String) SKIP1ST(String)(PARSER(Int) p1, PARSER(String) p2);
-PARSER(Int) SKIP1ST(Int)(PARSER(Int) p1, PARSER(Int) p2);
+#define DECLARE_SKIP1ST(T)                                               \
+  PARSER(T) SKIP1ST(T)(PARSER(Int) p1, PARSER(T) p2)
+
+DECLARE_SKIP1ST(Char);
+DECLARE_SKIP1ST(String);
+DECLARE_SKIP1ST(Int);
+DECLARE_SKIP1ST(List(String));
+DECLARE_SKIP1ST(List(Int));
 
 #define MANY(T) CAT(many_, T)
 // clang-format off
@@ -257,9 +272,11 @@ PARSER(Int) SKIP1ST(Int)(PARSER(Int) p1, PARSER(Int) p2);
            )(PARSER_CAST(p))
 // clang-format on
 
-PARSER(List(Char)) MANY(Char)(PARSER(Char) p);
-PARSER(List(String)) MANY(String)(PARSER(String) p);
-PARSER(List(Int)) MANY(Int)(PARSER(Int) p);
+#define DECLARE_MANY(T) PARSER(List(T)) MANY(T)(PARSER(T) p)
+
+DECLARE_MANY(Char);
+DECLARE_MANY(String);
+DECLARE_MANY(Int);
 
 #define MANY1(T) CAT(many1_, T)
 // clang-format off
@@ -271,9 +288,11 @@ PARSER(List(Int)) MANY(Int)(PARSER(Int) p);
            )(PARSER_CAST(p))
 // clang-format on
 
-PARSER(List(Char)) MANY1(Char)(PARSER(Char) p);
-PARSER(List(String)) MANY1(String)(PARSER(String) p);
-PARSER(List(Int)) MANY1(Int)(PARSER(Int) p);
+#define DECLARE_MANY1(T) PARSER(List(T)) MANY1(T)(PARSER(T) p)
+
+DECLARE_MANY1(Char);
+DECLARE_MANY1(String);
+DECLARE_MANY1(Int);
 
 // Parser<T[]> seq(Parser<T> p, ...);
 #define SEQ(T) CAT(seq_, T)
@@ -287,9 +306,11 @@ PARSER(List(Int)) MANY1(Int)(PARSER(Int) p);
            )((void*[]){p, __VA_ARGS__})
 // clang-format on
 
-PARSER(List(Char)) SEQ(Char)(void* ps[]);
-PARSER(List(String)) SEQ(String)(void* ps[]);
-PARSER(List(Int)) SEQ(Int)(void* ps[]);
+#define DECLARE_SEQ(T) PARSER(List(T)) SEQ(T)(void* ps[])
+
+DECLARE_SEQ(Char);
+DECLARE_SEQ(String);
+DECLARE_SEQ(Int);
 
 // Parser<T[]> cons(Parser<T> p, Parser<T[]> ps);
 #define CONS(T) CAT(cons_, T)
@@ -302,55 +323,75 @@ PARSER(List(Int)) SEQ(Int)(void* ps[]);
            )((PARSER_CAST(p)), (PARSER_CAST(ps)))
 // clang-format on
 
-PARSER(List(Char)) CONS(Char)(PARSER(Char) p, PARSER(List(Char)) ps);
-PARSER(List(String))
-CONS(String)(PARSER(String) p, PARSER(List(String)) ps);
-PARSER(List(Int)) CONS(Int)(PARSER(Int) p, PARSER(List(Int)) ps);
+#define DECLARE_CONS(T)                                                  \
+  PARSER(List(T)) CONS(T)(PARSER(T) p, PARSER(List(T)) ps)
+
+DECLARE_CONS(Char);
+DECLARE_CONS(String);
+DECLARE_CONS(Int);
 
 // Parser<T> either(Parser<T> p1, Parser<T> p2);
 #define EITHER(T) CAT(either_, T)
 // clang-format off
-#define either(p1, p2)                              \
-  _Generic((PARSER_CAST(p1))                        \
-           , PARSER(Char)   : EITHER(Char)          \
-           , PARSER(String) : EITHER(String)        \
-           , PARSER(Int)    : EITHER(Int)           \
+#define either(p1, p2)                                    \
+  _Generic((PARSER_CAST(p1))                              \
+           , PARSER(Char)         : EITHER(Char)          \
+           , PARSER(String)       : EITHER(String)        \
+           , PARSER(Int)          : EITHER(Int)           \
+           , PARSER(List(String)) : EITHER(List(String))  \
+           , PARSER(List(Int))    : EITHER(List(Int))     \
            )((PARSER_CAST(p1)), (PARSER_CAST(p2)))
 // clang-format on
 
-PARSER(Char) EITHER(Char)(PARSER(Char) p1, PARSER(Char) p2);
-PARSER(String) EITHER(String)(PARSER(String) p1, PARSER(String) p2);
-PARSER(Int) EITHER(Int)(PARSER(Int) p1, PARSER(Int) p2);
+#define DECLARE_EITHER(T) PARSER(T) EITHER(T)(PARSER(T) p1, PARSER(T) p2)
+
+DECLARE_EITHER(Char);
+DECLARE_EITHER(String);
+DECLARE_EITHER(Int);
+DECLARE_EITHER(List(String));
+DECLARE_EITHER(List(Int));
 
 // Parser<T> tryp(Parser<T> p);
 #define TRYP(T) CAT(tryp_, T)
 // clang-format off
-#define tryp(p)                                 \
-  _Generic((PARSER_CAST(p))                     \
-           , PARSER(Char)   : TRYP(Char)        \
-           , PARSER(String) : TRYP(String)      \
-           , PARSER(Int)    : TRYP(Int)         \
+#define tryp(p)                                         \
+  _Generic((PARSER_CAST(p))                             \
+           , PARSER(Char)         : TRYP(Char)          \
+           , PARSER(String)       : TRYP(String)        \
+           , PARSER(Int)          : TRYP(Int)           \
+           , PARSER(List(String)) : TRYP(List(String))  \
+           , PARSER(List(Int))    : TRYP(List(Int))     \
            )(PARSER_CAST(p))
 // clang-format on
 
-PARSER(Char) TRYP(Char)(PARSER(Char) p);
-PARSER(String) TRYP(String)(PARSER(String) p);
-PARSER(Int) TRYP(Int)(PARSER(Int) p);
+#define DECLARE_TRYP(T) PARSER(T) TRYP(T)(PARSER(T) p)
+
+DECLARE_TRYP(Char);
+DECLARE_TRYP(String);
+DECLARE_TRYP(Int);
+DECLARE_TRYP(List(String));
+DECLARE_TRYP(List(Int));
 
 // Parser<T> token(Parser<T> p);
 #define TOKEN(T) CAT(token_, T)
 // clang-format off
-#define token(p)                                \
-  _Generic((PARSER_CAST(p))                     \
-           , PARSER(Char)   : TOKEN(Char)       \
-           , PARSER(String) : TOKEN(String)     \
-           , PARSER(Int)    : TOKEN(Int)        \
+#define token(p)                                        \
+  _Generic((PARSER_CAST(p))                             \
+           , PARSER(Char)         : TOKEN(Char)         \
+           , PARSER(String)       : TOKEN(String)       \
+           , PARSER(Int)          : TOKEN(Int)          \
+           , PARSER(List(String)) : TOKEN(List(String)) \
+           , PARSER(List(Int))    : TOKEN(List(Int))    \
            )(PARSER_CAST(p))
 // clang-format on
 
-PARSER(Char) TOKEN(Char)(PARSER(Char) p);
-PARSER(String) TOKEN(String)(PARSER(String) p);
-PARSER(Int) TOKEN(Int)(PARSER(Int) p);
+#define DECLARE_TOKEN(T) PARSER(T) TOKEN(T)(PARSER(T) p)
+
+DECLARE_TOKEN(Char);
+DECLARE_TOKEN(String);
+DECLARE_TOKEN(Int);
+DECLARE_TOKEN(List(String));
+DECLARE_TOKEN(List(Int));
 
 #ifdef __cplusplus
 }

--- a/include/cparsec2.hpp
+++ b/include/cparsec2.hpp
@@ -43,6 +43,12 @@ inline PARSER(Int) skip(PARSER(String) p) {
 inline PARSER(Int) skip(PARSER(Int) p) {
   return SKIP(Int)(p);
 }
+inline PARSER(Int) skip(PARSER(List(String)) p) {
+  return SKIP(List(String))(p);
+}
+inline PARSER(Int) skip(PARSER(List(Int)) p) {
+  return SKIP(List(Int))(p);
+}
 #endif
 
 #ifdef skip1st
@@ -58,6 +64,14 @@ inline PARSER(String) skip1st(P p1, PARSER(String) p2) {
 template <typename P>
 inline PARSER(Int) skip1st(P p1, PARSER(Int) p2) {
   return SKIP1ST(Int)(skip(p1), p2);
+}
+template <typename P>
+inline PARSER(List(String)) skip1st(P p1, PARSER(List(String)) p2) {
+  return SKIP1ST(List(String))(skip(p1), p2);
+}
+template <typename P>
+inline PARSER(List(Int)) skip1st(P p1, PARSER(List(Int)) p2) {
+  return SKIP1ST(List(Int))(skip(p1), p2);
 }
 #endif
 
@@ -149,6 +163,14 @@ inline PARSER(String) either(PARSER(String) p1, PARSER(String) p2) {
 inline PARSER(Int) either(PARSER(Int) p1, PARSER(Int) p2) {
   return EITHER(Int)(p1, p2);
 }
+inline PARSER(List(String))
+    either(PARSER(List(String)) p1, PARSER(List(String)) p2) {
+  return EITHER(List(String))(p1, p2);
+}
+inline PARSER(List(Int))
+    either(PARSER(List(Int)) p1, PARSER(List(Int)) p2) {
+  return EITHER(List(Int))(p1, p2);
+}
 #endif
 
 #ifdef tryp
@@ -156,17 +178,23 @@ inline PARSER(Int) either(PARSER(Int) p1, PARSER(Int) p2) {
 inline PARSER(Char) tryp(char p) {
   return TRYP(Char)(char1(p));
 }
-inline PARSER(Char) tryp(PARSER(Char) p) {
-  return TRYP(Char)(p);
-}
 inline PARSER(String) tryp(const char* s) {
   return TRYP(String)(string1(s));
+}
+inline PARSER(Char) tryp(PARSER(Char) p) {
+  return TRYP(Char)(p);
 }
 inline PARSER(String) tryp(PARSER(String) p) {
   return TRYP(String)(p);
 }
 inline PARSER(Int) tryp(PARSER(Int) p) {
   return TRYP(Int)(p);
+}
+inline PARSER(List(String)) tryp(PARSER(List(String)) p) {
+  return TRYP(List(String))(p);
+}
+inline PARSER(List(Int)) tryp(PARSER(List(Int)) p) {
+  return TRYP(List(Int))(p);
 }
 #endif
 
@@ -175,16 +203,22 @@ inline PARSER(Int) tryp(PARSER(Int) p) {
 inline PARSER(Char) token(char c) {
   return TOKEN(Char)(char1(c));
 }
-inline PARSER(Char) token(PARSER(Char) p) {
-  return TOKEN(Char)(p);
-}
 inline PARSER(String) token(const char* s) {
   return TOKEN(String)(string1(s));
+}
+inline PARSER(Char) token(PARSER(Char) p) {
+  return TOKEN(Char)(p);
 }
 inline PARSER(String) token(PARSER(String) p) {
   return TOKEN(String)(p);
 }
 inline PARSER(Int) token(PARSER(Int) p) {
   return TOKEN(Int)(p);
+}
+inline PARSER(List(String)) token(PARSER(List(String)) p) {
+  return TOKEN(List(String))(p);
+}
+inline PARSER(List(Int)) token(PARSER(List(Int)) p) {
+  return TOKEN(List(Int))(p);
 }
 #endif

--- a/include/cparsec2.hpp
+++ b/include/cparsec2.hpp
@@ -34,6 +34,12 @@ inline std::string parse(PARSER(String) p, Source src) {
 
 #ifdef skip
 #undef skip
+inline PARSER(Int) skip(char c) {
+  return SKIP(Char)(char1(c));
+}
+inline PARSER(Int) skip(const char* s) {
+  return SKIP(String)(string1(s));
+}
 inline PARSER(Int) skip(PARSER(Char) p) {
   return SKIP(Char)(p);
 }
@@ -53,6 +59,14 @@ inline PARSER(Int) skip(PARSER(List(Int)) p) {
 
 #ifdef skip1st
 #undef skip1st
+template <typename P>
+inline PARSER(Char) skip1st(P p1, char c) {
+  return SKIP1ST(Char)(p1, char1(c));
+}
+template <typename P>
+inline PARSER(String) skip1st(P p1, const char* s) {
+  return SKIP1ST(String)(p1, string1(s));
+}
 template <typename P>
 inline PARSER(Char) skip1st(P p1, PARSER(Char) p2) {
   return SKIP1ST(Char)(skip(p1), p2);
@@ -77,6 +91,12 @@ inline PARSER(List(Int)) skip1st(P p1, PARSER(List(Int)) p2) {
 
 #ifdef many
 #undef many
+inline PARSER(List(Char)) many(char c) {
+  return MANY(Char)(char1(c));
+}
+inline PARSER(List(String)) many(const char* s) {
+  return MANY(String)(string1(s));
+}
 inline PARSER(List(Char)) many(PARSER(Char) p) {
   return MANY(Char)(p);
 }
@@ -90,6 +110,12 @@ inline PARSER(List(Int)) many(PARSER(Int) p) {
 
 #ifdef many1
 #undef many1
+inline PARSER(List(Char)) many1(char c) {
+  return MANY1(Char)(char1(c));
+}
+inline PARSER(List(String)) many1(const char* s) {
+  return MANY1(String)(string1(s));
+}
 inline PARSER(List(Char)) many1(PARSER(Char) p) {
   return MANY1(Char)(p);
 }
@@ -122,6 +148,18 @@ inline PARSER(List(Int)) seq(PARSER(Int) p, Parser... args) {
 
 #ifdef cons
 #undef cons
+inline PARSER(List(Char)) cons(char c, const char* s) {
+  return CONS(Char)(char1(c), string1(s));
+}
+inline PARSER(List(Char)) cons(char c, PARSER(List(Char)) ps) {
+  return CONS(Char)(char1(c), ps);
+}
+inline PARSER(List(Char)) cons(PARSER(Char) p, const char* s) {
+  return CONS(Char)(p, string1(s));
+}
+inline PARSER(List(String)) cons(const char* s, PARSER(List(String)) ps) {
+  return CONS(String)(string1(s), ps);
+}
 inline PARSER(List(Char)) cons(PARSER(Char) p, PARSER(List(Char)) ps) {
   return CONS(Char)(p, ps);
 }

--- a/src/either.c
+++ b/src/either.c
@@ -29,3 +29,5 @@
 DEFINE_EITHER(Char, char);
 DEFINE_EITHER(String, const char*);
 DEFINE_EITHER(Int, int);
+DEFINE_EITHER(List(String), List(String));
+DEFINE_EITHER(List(Int), List(Int));

--- a/src/many.c
+++ b/src/many.c
@@ -21,7 +21,7 @@
     return buff_finish(&str);                                            \
   }                                                                      \
   PARSER(List(T)) MANY(T)(PARSER(T) p) {                                 \
-    return PARSER_GEN(List(T))(MANY_FN(T), p);                           \
+    return PARSER_GEN(List(T))(MANY_FN(T), tryp(p));                     \
   }                                                                      \
   _Static_assert(1, "")
 

--- a/src/many1.c
+++ b/src/many1.c
@@ -2,25 +2,9 @@
 
 #include "cparsec2.h"
 
-#define MANY1_FN(T) CAT(run_many1, T)
 #define DEFINE_MANY1(T)                                                  \
-  static List(T) MANY1_FN(T)(void* arg, Source src, Ctx* ex) {           \
-    PARSER(T) parser = (PARSER(T))arg;                                   \
-    Ctx ctx;                                                             \
-    Buff(T) str = {0};                                                   \
-    TRY(&ctx) {                                                          \
-      buff_push(&str, parse(parser, src, &ctx));                         \
-      buff_append(&str, parse(many(parser), src, &ctx));                 \
-      return buff_finish(&str);                                          \
-    }                                                                    \
-    else {                                                               \
-      mem_free((void*)str.data);                                         \
-      /* catch and re-throw exception */                                 \
-      cthrow(ex, ctx.msg);                                               \
-    }                                                                    \
-  }                                                                      \
   PARSER(List(T)) MANY1(T)(PARSER(T) p) {                                \
-    return PARSER_GEN(List(T))(MANY1_FN(T), p);                          \
+    return cons(p, many(p));                                             \
   }                                                                      \
   _Static_assert(1, "")
 

--- a/src/skip.c
+++ b/src/skip.c
@@ -17,3 +17,5 @@
 DEFINE_SKIP(Char);
 DEFINE_SKIP(String);
 DEFINE_SKIP(Int);
+DEFINE_SKIP(List(String));
+DEFINE_SKIP(List(Int));

--- a/src/skip1st.c
+++ b/src/skip1st.c
@@ -20,3 +20,5 @@
 DEFINE_SKIP1ST(Char, char);
 DEFINE_SKIP1ST(String, const char*);
 DEFINE_SKIP1ST(Int, int);
+DEFINE_SKIP1ST(List(String), List(String));
+DEFINE_SKIP1ST(List(Int), List(Int));

--- a/src/token.c
+++ b/src/token.c
@@ -2,17 +2,14 @@
 
 #include "cparsec2.h"
 
-#define TOKEN_FN(T) run_token##T
-#define DEFINE_TOKEN(T, R)                                               \
-  static R TOKEN_FN(T)(void* arg, Source src, Ctx* ex) {                 \
-    parse(spaces, src, ex);                                              \
-    return parse((PARSER(T))arg, src, ex);                               \
-  }                                                                      \
+#define DEFINE_TOKEN(T)                                                  \
   PARSER(T) TOKEN(T)(PARSER(T) p) {                                      \
-    return PARSER_GEN(T)(TOKEN_FN(T), p);                                \
+    return skip1st(spaces, p);                                           \
   }                                                                      \
   _Static_assert(1, "")
 
-DEFINE_TOKEN(Char, char);
-DEFINE_TOKEN(String, const char*);
-DEFINE_TOKEN(Int, int);
+DEFINE_TOKEN(Char);
+DEFINE_TOKEN(String);
+DEFINE_TOKEN(Int);
+DEFINE_TOKEN(List(String));
+DEFINE_TOKEN(List(Int));

--- a/src/tryp.c
+++ b/src/tryp.c
@@ -24,3 +24,5 @@
 DEFINE_TRYP(Char, char);
 DEFINE_TRYP(String, const char*);
 DEFINE_TRYP(Int, int);
+DEFINE_TRYP(List(String), List(String));
+DEFINE_TRYP(List(Int), List(Int));

--- a/test/src/test_many.cpp
+++ b/test/src/test_many.cpp
@@ -83,5 +83,58 @@ SCENARIO("many(p)", "[cparsec2][parser][many]") {
       }
     }
   }
+  GIVEN("an input \",123,abc\"") {
+    Source src = Source_new(",123,abc");
+    WHEN("apply many(skip1st(char1(','), number))") {
+      List(Int) xs = parse(many(skip1st(char1(','), number)), src);
+      THEN("results [123]") {
+        int* itr = list_begin(xs);
+        REQUIRE(123 == itr[0]);
+        AND_WHEN("apply string1(\",abc\")") {
+          THEN("results \",abc\"") {
+            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+          }
+        }
+      }
+    }
+    WHEN("apply many(skip1st(char1(','), many1(digit)))") {
+      List(String) xs =
+        parse(many(skip1st(char1(','), many1(digit))), src);
+      THEN("results [\"123\"]") {
+        const char** itr = list_begin(xs);
+        REQUIRE("123" == std::string(itr[0]));
+        AND_WHEN("apply string1(\",abc\")") {
+          THEN("results \",abc\"") {
+            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+          }
+        }
+      }
+    }
+  }
+  GIVEN("an input \",abc\"") {
+    Source src = Source_new(",abc");
+    WHEN("apply many(skip1st(char1(','), number))") {
+      List(Int) xs = parse(many(skip1st(char1(','), number)), src);
+      THEN("results []") {
+        REQUIRE(list_begin(xs) == list_end(xs));
+        AND_WHEN("apply string1(\",abc\")") {
+          THEN("results \",abc\"") {
+            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+          }
+        }
+      }
+    }
+    WHEN("apply many(skip1st(char1(','), many1(digit)))") {
+      List(String) xs = parse(many(skip1st(char1(','), many1(digit))), src);
+      THEN("results []") {
+        REQUIRE(list_begin(xs) == list_end(xs));
+        AND_WHEN("apply string1(\",abc\")") {
+          THEN("results \",abc\"") {
+            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+          }
+        }
+      }
+    }
+  }
   cparsec2_end();
 }

--- a/test/src/test_many1.cpp
+++ b/test/src/test_many1.cpp
@@ -83,5 +83,62 @@ SCENARIO("many1(p)", "[cparsec2][parser][many1]") {
       }
     }
   }
+  GIVEN("an input \",123,abc\"") {
+    Source src = Source_new(",123,abc");
+    WHEN("apply many1(skip1st(char1(','), number))") {
+      List(Int) xs = parse(many1(skip1st(char1(','), number)), src);
+      THEN("results [123]") {
+        int* itr = list_begin(xs);
+        REQUIRE(123 == itr[0]);
+        AND_WHEN("apply string1(\",abc\")") {
+          THEN("results \",abc\"") {
+            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+          }
+        }
+      }
+    }
+    WHEN("apply many1(skip1st(char1(','), many1(digit)))") {
+      List(String) xs =
+          parse(many1(skip1st(char1(','), many1(digit))), src);
+      THEN("results [\"123\"]") {
+        const char** itr = list_begin(xs);
+        REQUIRE("123" == std::string(itr[0]));
+        AND_WHEN("apply string1(\",abc\")") {
+          THEN("results \",abc\"") {
+            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+          }
+        }
+      }
+    }
+  }
+  GIVEN("an input \",abc\"") {
+    Source src = Source_new(",abc");
+    WHEN("apply many1(skip1st(char1(','), number))") {
+      THEN("cause exception(\"not satisfy\")") {
+        REQUIRE_THROWS_WITH(
+            parse(many1(skip1st(char1(','), number)), src),
+            "not satisfy");
+        AND_WHEN("apply string1(\",abc\")") {
+          THEN("cause exception(\"expects ',' but was 'a'\")") {
+            REQUIRE_THROWS_WITH(parse(string1(",abc"), src),
+                                "expects ',' but was 'a'");
+          }
+        }
+      }
+    }
+    WHEN("apply many1(skip1st(char1(','), many1(digit)))") {
+      THEN("cause exception(\"not satisfy\")") {
+        REQUIRE_THROWS_WITH(
+            parse(many1(skip1st(char1(','), many1(digit))), src),
+            "not satisfy");
+        AND_WHEN("apply string1(\",abc\")") {
+          THEN("cause exception(\"expects ',' but was 'a'\")") {
+            REQUIRE_THROWS_WITH(parse(string1(",abc"), src),
+                                "expects ',' but was 'a'");
+          }
+        }
+      }
+    }
+  }
   cparsec2_end();
 }

--- a/test/src/test_skip.cpp
+++ b/test/src/test_skip.cpp
@@ -40,5 +40,39 @@ SCENARIO("skip", "[cparsec2][parser][skip]") {
       }
     }
   }
+
+  GIVEN("an input: \"123 456 789\"") {
+    Source src = Source_new("123 456 789");
+    WHEN("apply skip(number)") {
+      THEN("success") {
+        REQUIRE_NOTHROW(parse(skip(number), src));
+        AND_WHEN("apply string1(\" 456 789\")") {
+          THEN("results \" 456 789\"") {
+            REQUIRE(" 456 789" == parse(string1(" 456 789"), src));
+          }
+        }
+      }
+    }
+    WHEN("apply skip(many1(number))") {
+      THEN("success") {
+        REQUIRE_NOTHROW(parse(skip(many1(number)), src));
+        AND_WHEN("apply anyChar") {
+          THEN("causes exception(\"too short\")") {
+            REQUIRE_THROWS_WITH(parse(anyChar, src), "too short");
+          }
+        }
+      }
+    }
+    WHEN("apply skip(many1(token(many1(digit))))") {
+      THEN("success") {
+        REQUIRE_NOTHROW(parse(skip(many1(token(many1(digit)))), src));
+        AND_WHEN("apply anyChar") {
+          THEN("causes exception(\"too short\")") {
+            REQUIRE_THROWS_WITH(parse(anyChar, src), "too short");
+          }
+        }
+      }
+    }
+  }
   cparsec2_end();
 }

--- a/test/src/test_token.cpp
+++ b/test/src/test_token.cpp
@@ -105,3 +105,32 @@ SCENARIO("token(\"foo\")", "[cparsec2][parser][token]") {
   }
   cparsec2_end();
 }
+
+SCENARIO("token(PARSER(List(T)))", "[cparsec2][parser][token]") {
+  cparsec2_init();
+  GIVEN("an input: \"  , 123,456,  789\"") {
+    Source src = Source_new("  , 123,456,  789");
+    WHEN("apply token(p) where p = many(skip1st(',', number))") {
+      PARSER(List(Int)) p = many(skip1st(',', number));
+      List(Int) xs = parse(token(p), src);
+      THEN("results [123, 456, 789]") {
+        int* itr = list_begin(xs);
+        REQUIRE(123 == itr[0]);
+        REQUIRE(456 == itr[1]);
+        REQUIRE(789 == itr[2]);
+      }
+    }
+    WHEN("apply token(p) where "
+         "p = many(skip1st(',', token(many1(digit))))") {
+      PARSER(List(String)) p = many(skip1st(',', token(many1(digit))));
+      List(String) xs = parse(token(p), src);
+      THEN("results [\"123\", \"456\", \"789\"]") {
+        const char** itr = list_begin(xs);
+        REQUIRE("123" == std::string(itr[0]));
+        REQUIRE("456" == std::string(itr[1]));
+        REQUIRE("789" == std::string(itr[2]));
+      }
+    }
+  }
+  cparsec2_end();
+}

--- a/test/src/test_tryp.cpp
+++ b/test/src/test_tryp.cpp
@@ -64,3 +64,56 @@ SCENARIO("tryp(p)", "[cparsec2][parser][tryp]") {
 
   cparsec2_end();
 }
+
+SCENARIO("tryp(PARSER(List(T)))", "[cparsec2][parser][tryp]") {
+  cparsec2_init();
+  GIVEN("an input: \",123,456,789\"") {
+    Source src = Source_new(",123,456,789");
+    WHEN("apply tryp(p) where p = many(skip1st(',', number))") {
+      PARSER(List(Int)) p = many(skip1st(',', number));
+      List(Int) xs = parse(tryp(p), src);
+      THEN("results [123, 456, 789]") {
+        int* itr = list_begin(xs);
+        REQUIRE(123 == itr[0]);
+        REQUIRE(456 == itr[1]);
+        REQUIRE(789 == itr[2]);
+      }
+    }
+    WHEN("apply tryp(p) where p = many(skip1st(',', many1(digit)))") {
+      PARSER(List(String)) p = many(skip1st(',', many1(digit)));
+      List(String) xs = parse(tryp(p), src);
+      THEN("results [\"123\", \"456\", \"789\"]") {
+        const char** itr = list_begin(xs);
+        REQUIRE("123" == std::string(itr[0]));
+        REQUIRE("456" == std::string(itr[1]));
+        REQUIRE("789" == std::string(itr[2]));
+      }
+    }
+  }
+  GIVEN("an input \",abc\"") {
+    Source src = Source_new(",abc");
+    WHEN("apply tryp(skip1st(char1(','), number))") {
+      THEN("cause exception(\"not satisfy\")") {
+        REQUIRE_THROWS_WITH(parse(tryp(skip1st(char1(','), number)), src),
+                            "not satisfy");
+        AND_WHEN("apply string1(\",abc\")") {
+          THEN("results \",abc\"") {
+            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+          }
+        }
+      }
+    }
+    WHEN("apply tryp(skip1st(char1(','), many1(digit)))") {
+      THEN("cause exception(\"not satisfy\")") {
+        REQUIRE_THROWS_WITH(parse(tryp(skip1st(char1(','), many1(digit))), src),
+                            "not satisfy");
+        AND_WHEN("apply string1(\",abc\")") {
+          THEN("results \",abc\"") {
+            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+          }
+        }
+      }
+    }
+  }
+  cparsec2_end();
+}


### PR DESCRIPTION
fixed #37
added support for PARSER(List(String)) and PARSER(List(Int))
- skip(p) (internal use only)
- skip1st(p1, p2)
- either(p1, p2)
- tryp(p)
- token(p)

and refactored:
- many1(p)  ; many1(p) is cons(p, many(p))
- token(p)  ; token(p) is skip1st(spaces, p)