### PR TITLE
replaced parse() and PARSE_TEST() with type-safe macros/functions

### DIFF
--- a/include/cparsec2.hpp
+++ b/include/cparsec2.hpp
@@ -18,30 +18,32 @@ inline PARSER(String) parser_cast(const char* s) {
 
 #ifdef parse
 #undef parse
+#define parse(p, src) cxx_parse(p, src)
+#define DEFINE_CXX_PARSE(T)                                              \
+  inline auto cxx_parse(PARSER(T) p, Source src) {                       \
+    Ctx ctx;                                                             \
+    TRY(&ctx) {                                                          \
+      return PARSE(T)(p, src, &ctx);                                     \
+    }                                                                    \
+    else {                                                               \
+      throw std::string(ctx.msg);                                        \
+    }                                                                    \
+  }                                                                      \
+  END_OF_STATEMENTS
+FOREACH(DEFINE_CXX_PARSE, TYPESET(1));
 #endif
 
-template <typename Parser>
-inline auto parse(Parser p, Source src) {
-  Ctx ctx;
-  TRY(&ctx) {
-    return p->run(p->arg, src, &ctx);
-  }
-  else {
-    std::string ex(ctx.msg);
-    throw ex;
-  }
-}
-
-inline std::string parse(PARSER(String) p, Source src) {
-  Ctx ctx;
-  TRY(&ctx) {
-    return p->run(p->arg, src, &ctx);
-  }
-  else {
-    std::string ex(ctx.msg);
-    throw ex;
-  }
-}
+#ifdef PARSE_TEST_I
+#undef PARSE_TEST_I
+#define PARSE_TEST_I(msg, p, input) cxx_parsetest(msg, p, input)
+#define DEFINE_CXX_PARSETEST(T)                                          \
+  inline auto cxx_parsetest(const char* msg, PARSER(T) p,                \
+                            const char* input) {                         \
+    return PARSETEST(T)(msg, p, input);                                  \
+  }                                                                      \
+  END_OF_STATEMENTS
+FOREACH(DEFINE_CXX_PARSETEST, TYPESET(1));
+#endif
 
 #ifdef many
 #undef many

--- a/test/src/test_cons.cpp
+++ b/test/src/test_cons.cpp
@@ -9,7 +9,8 @@ SCENARIO("cons(letter, many(digit))", "[cparsec2][parser][cons]") {
     Source src = Source_new("a1234");
     WHEN("apply cons(letter, many(digit))") {
       THEN("results \"a1234\"") {
-        REQUIRE("a1234" == parse(cons(letter, many(digit)), src));
+        REQUIRE(std::string("a1234") ==
+                parse(cons(letter, many(digit)), src));
       }
     }
   }
@@ -17,7 +18,8 @@ SCENARIO("cons(letter, many(digit))", "[cparsec2][parser][cons]") {
     Source src = Source_new("abc123");
     WHEN("apply cons(letter, many(digit))") {
       THEN("results \"a\"") {
-        REQUIRE("a" == parse(cons(letter, many(digit)), src));
+        REQUIRE(std::string("a") ==
+                parse(cons(letter, many(digit)), src));
       }
     }
   }
@@ -25,7 +27,8 @@ SCENARIO("cons(letter, many(digit))", "[cparsec2][parser][cons]") {
     Source src = Source_new("a123bc");
     WHEN("apply cons(letter, many(digit))") {
       THEN("results \"a123\"") {
-        REQUIRE("a123" == parse(cons(letter, many(digit)), src));
+        REQUIRE(std::string("a123") ==
+                parse(cons(letter, many(digit)), src));
       }
     }
   }
@@ -59,9 +62,9 @@ SCENARIO("cons(p, ps)", "[cparsec2][parser][cons]") {
       List(String) xs = parse(cons(x, many(x)), src);
       THEN("results [\"123\", \"456\", \"789\"]") {
         const char** itr = list_begin(xs);
-        REQUIRE("123" == std::string(itr[0]));
-        REQUIRE("456" == std::string(itr[1]));
-        REQUIRE("789" == std::string(itr[2]));
+        REQUIRE(std::string("123") == itr[0]);
+        REQUIRE(std::string("456") == itr[1]);
+        REQUIRE(std::string("789") == itr[2]);
       }
     }
   }

--- a/test/src/test_either.cpp
+++ b/test/src/test_either.cpp
@@ -11,13 +11,13 @@ SCENARIO("either(p1, p2)", "[cparsec2][parser][either]") {
     WHEN("applied to an input: \"ab\"") {
       Source src = Source_new("ab");
       THEN("results \"ab\"") {
-        REQUIRE("ab" == parse(p, src));
+        REQUIRE(std::string("ab") == parse(p, src));
       }
     }
     WHEN("applied to an input: \"bc\"") {
       Source src = Source_new("bc");
       THEN("results \"bc\"") {
-        REQUIRE("bc" == parse(p, src));
+        REQUIRE(std::string("bc") == parse(p, src));
       }
     }
     WHEN("applied to an input: \"ac\"") {
@@ -45,13 +45,13 @@ SCENARIO("either(p1, p2)", "[cparsec2][parser][either]") {
     WHEN("applied to an input: \"ab\"") {
       Source src = Source_new("ab");
       THEN("results \"ab\"") {
-        REQUIRE("ab" == parse(p, src));
+        REQUIRE(std::string("ab") == parse(p, src));
       }
     }
     WHEN("applied to an input: \"bc\"") {
       Source src = Source_new("bc");
       THEN("results \"bc\"") {
-        REQUIRE("bc" == parse(p, src));
+        REQUIRE(std::string("bc") == parse(p, src));
       }
     }
     WHEN("applied to an input: \"ac\"") {
@@ -124,8 +124,10 @@ SCENARIO("either(p1, p2)", "[cparsec2][parser][either]") {
     }
   }
 
-  GIVEN("PARSER(List(Int)) p = either(many1(number), many1(skip1st(\"++\", number)))") {
-    PARSER(List(Int)) p = either(many1(number), many1(skip1st("++", number)));
+  GIVEN("PARSER(List(Int)) p = either(many1(number), "
+        "many1(skip1st(\"++\", number)))") {
+    PARSER(List(Int))
+    p = either(many1(number), many1(skip1st("++", number)));
     WHEN("applied to an input: \"123++456++789\"") {
       Source src = Source_new("123++456++789");
       List(Int) xs = parse(p, src);
@@ -154,14 +156,16 @@ SCENARIO("either(p1, p2)", "[cparsec2][parser][either]") {
     }
   }
 
-  GIVEN("PARSER(List(String)) p = either(many1(many1(digit)), many1(skip1st(\"++\", many1(digit))))") {
-    PARSER(List(String)) p = either(many1(many1(digit)), many1(skip1st("++", many1(digit))));
+  GIVEN("PARSER(List(String)) p = either(many1(many1(digit)), "
+        "many1(skip1st(\"++\", many1(digit))))") {
+    PARSER(List(String))
+    p = either(many1(many1(digit)), many1(skip1st("++", many1(digit))));
     WHEN("applied to an input: \"123++456++789\"") {
       Source src = Source_new("123++456++789");
       List(String) xs = parse(p, src);
       THEN("results [\"123\"]") {
         const char** itr = list_begin(xs);
-        REQUIRE("123" == std::string(itr[0]));
+        REQUIRE(std::string("123") == itr[0]);
         REQUIRE(list_end(xs) == itr + 1);
       }
     }
@@ -170,9 +174,9 @@ SCENARIO("either(p1, p2)", "[cparsec2][parser][either]") {
       List(String) xs = parse(p, src);
       THEN("results [\"123\", \"456\", \"789\"]") {
         const char** itr = list_begin(xs);
-        REQUIRE("123" == std::string(itr[0]));
-        REQUIRE("456" == std::string(itr[1]));
-        REQUIRE("789" == std::string(itr[2]));
+        REQUIRE(std::string("123") == itr[0]);
+        REQUIRE(std::string("456") == itr[1]);
+        REQUIRE(std::string("789") == itr[2]);
         REQUIRE(list_end(xs) == itr + 3);
       }
     }

--- a/test/src/test_hexDigit.cpp
+++ b/test/src/test_hexDigit.cpp
@@ -41,7 +41,8 @@ SCENARIO("hexDigit", "[cparsec2][parser][hexDigit]") {
     Source src = Source_new("0123456789abcdefg");
     WHEN("apply many1(hexDigit)") {
       THEN("reaulst \"0123456789abcdef\"") {
-        REQUIRE("0123456789abcdef" == parse(many1(hexDigit), src));
+        REQUIRE(std::string("0123456789abcdef") ==
+                parse(many1(hexDigit), src));
       }
     }
   }
@@ -49,7 +50,8 @@ SCENARIO("hexDigit", "[cparsec2][parser][hexDigit]") {
     Source src = Source_new("0123456789ABCDEFG");
     WHEN("apply many1(hexDigit)") {
       THEN("reaulst \"0123456789ABCDEF\"") {
-        REQUIRE("0123456789ABCDEF" == parse(many1(hexDigit), src));
+        REQUIRE(std::string("0123456789ABCDEF") ==
+                parse(many1(hexDigit), src));
       }
     }
   }

--- a/test/src/test_many.cpp
+++ b/test/src/test_many.cpp
@@ -9,7 +9,7 @@ SCENARIO("many(p)", "[cparsec2][parser][many]") {
     Source src = Source_new("1234567890abc");
     WHEN("apply many(digit)") {
       THEN("results \"1234567890\"") {
-        REQUIRE("1234567890" == parse(many(digit), src));
+        REQUIRE(std::string("1234567890") == parse(many(digit), src));
       }
     }
   }
@@ -17,15 +17,15 @@ SCENARIO("many(p)", "[cparsec2][parser][many]") {
     Source src = Source_new("aaabbb");
     WHEN("apply many(digit)") {
       THEN("results \"\"") {
-        REQUIRE("" == parse(many(digit), src));
+        REQUIRE(std::string("") == parse(many(digit), src));
       }
     }
     WHEN("apply many(char1('a'))") {
       AND_WHEN("apply many(char1('c'))") {
         THEN("results \"aaa\"") {
-          REQUIRE("aaa" == parse(many(char1('a')), src));
+          REQUIRE(std::string("aaa") == parse(many(char1('a')), src));
           AND_THEN("results \"\"") {
-            REQUIRE("" == parse(many(char1('c')), src));
+            REQUIRE(std::string("") == parse(many(char1('c')), src));
           }
         }
       }
@@ -34,9 +34,9 @@ SCENARIO("many(p)", "[cparsec2][parser][many]") {
       AND_WHEN("apply many(char1('b'))") {
         AND_WHEN("apply a parser (ex. alpha)") {
           THEN("results \"aaa\"") {
-            REQUIRE("aaa" == parse(many(char1('a')), src));
+            REQUIRE(std::string("aaa") == parse(many(char1('a')), src));
             AND_THEN("results \"bbb\"") {
-              REQUIRE("bbb" == parse(many(char1('b')), src));
+              REQUIRE(std::string("bbb") == parse(many(char1('b')), src));
               AND_THEN("cause exception(\"too short\")") {
                 REQUIRE_THROWS_WITH(parse(alpha, src), "too short");
               }
@@ -77,9 +77,9 @@ SCENARIO("many(p)", "[cparsec2][parser][many]") {
           parse(many(skip1st(char1(','), many1(digit))), src);
       THEN("results [\"123\", \"456\", \"789\"]") {
         const char** itr = list_begin(xs);
-        REQUIRE("123" == std::string(itr[0]));
-        REQUIRE("456" == std::string(itr[1]));
-        REQUIRE("789" == std::string(itr[2]));
+        REQUIRE(std::string("123") == itr[0]);
+        REQUIRE(std::string("456") == itr[1]);
+        REQUIRE(std::string("789") == itr[2]);
       }
     }
   }
@@ -92,20 +92,20 @@ SCENARIO("many(p)", "[cparsec2][parser][many]") {
         REQUIRE(123 == itr[0]);
         AND_WHEN("apply string1(\",abc\")") {
           THEN("results \",abc\"") {
-            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+            REQUIRE(std::string(",abc") == parse(string1(",abc"), src));
           }
         }
       }
     }
     WHEN("apply many(skip1st(char1(','), many1(digit)))") {
       List(String) xs =
-        parse(many(skip1st(char1(','), many1(digit))), src);
+          parse(many(skip1st(char1(','), many1(digit))), src);
       THEN("results [\"123\"]") {
         const char** itr = list_begin(xs);
-        REQUIRE("123" == std::string(itr[0]));
+        REQUIRE(std::string("123") == itr[0]);
         AND_WHEN("apply string1(\",abc\")") {
           THEN("results \",abc\"") {
-            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+            REQUIRE(std::string(",abc") == parse(string1(",abc"), src));
           }
         }
       }
@@ -119,18 +119,19 @@ SCENARIO("many(p)", "[cparsec2][parser][many]") {
         REQUIRE(list_begin(xs) == list_end(xs));
         AND_WHEN("apply string1(\",abc\")") {
           THEN("results \",abc\"") {
-            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+            REQUIRE(std::string(",abc") == parse(string1(",abc"), src));
           }
         }
       }
     }
     WHEN("apply many(skip1st(char1(','), many1(digit)))") {
-      List(String) xs = parse(many(skip1st(char1(','), many1(digit))), src);
+      List(String) xs =
+          parse(many(skip1st(char1(','), many1(digit))), src);
       THEN("results []") {
         REQUIRE(list_begin(xs) == list_end(xs));
         AND_WHEN("apply string1(\",abc\")") {
           THEN("results \",abc\"") {
-            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+            REQUIRE(std::string(",abc") == parse(string1(",abc"), src));
           }
         }
       }

--- a/test/src/test_many1.cpp
+++ b/test/src/test_many1.cpp
@@ -9,7 +9,7 @@ SCENARIO("many1(p)", "[cparsec2][parser][many1]") {
     Source src = Source_new("1234567890abc");
     WHEN("apply many1(digit)") {
       THEN("results \"1234567890\"") {
-        REQUIRE("1234567890" == parse(many1(digit), src));
+        REQUIRE(std::string("1234567890") == parse(many1(digit), src));
       }
     }
   }
@@ -23,7 +23,7 @@ SCENARIO("many1(p)", "[cparsec2][parser][many1]") {
     WHEN("apply many1(char1('a'))") {
       AND_WHEN("apply many1(char1('c'))") {
         THEN("results \"aaa\"") {
-          REQUIRE("aaa" == parse(many1(char1('a')), src));
+          REQUIRE(std::string("aaa") == parse(many1(char1('a')), src));
           AND_THEN("cause exception(\"expects 'c' but was 'b'\")") {
             REQUIRE_THROWS_WITH(parse(many1(char1('c')), src),
                                 "expects 'c' but was 'b'");
@@ -35,9 +35,9 @@ SCENARIO("many1(p)", "[cparsec2][parser][many1]") {
       AND_WHEN("apply many1(char1('b'))") {
         AND_WHEN("apply a parser (ex. alpha)") {
           THEN("results \"aaa\"") {
-            REQUIRE("aaa" == parse(many1(char1('a')), src));
+            REQUIRE(std::string("aaa") == parse(many1(char1('a')), src));
             AND_THEN("results \"bbb\"") {
-              REQUIRE("bbb" == parse(many1(char1('b')), src));
+              REQUIRE(std::string("bbb") == parse(many1(char1('b')), src));
               AND_THEN("cause exception(\"too short\")") {
                 REQUIRE_THROWS_WITH(parse(alpha, src), "too short");
               }
@@ -77,9 +77,9 @@ SCENARIO("many1(p)", "[cparsec2][parser][many1]") {
           parse(many1(skip1st(char1(','), many1(digit))), src);
       THEN("results [\"123\", \"456\", \"789\"]") {
         const char** itr = list_begin(xs);
-        REQUIRE("123" == std::string(itr[0]));
-        REQUIRE("456" == std::string(itr[1]));
-        REQUIRE("789" == std::string(itr[2]));
+        REQUIRE(std::string("123") == itr[0]);
+        REQUIRE(std::string("456") == itr[1]);
+        REQUIRE(std::string("789") == itr[2]);
       }
     }
   }
@@ -92,7 +92,7 @@ SCENARIO("many1(p)", "[cparsec2][parser][many1]") {
         REQUIRE(123 == itr[0]);
         AND_WHEN("apply string1(\",abc\")") {
           THEN("results \",abc\"") {
-            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+            REQUIRE(std::string(",abc") == parse(string1(",abc"), src));
           }
         }
       }
@@ -102,10 +102,10 @@ SCENARIO("many1(p)", "[cparsec2][parser][many1]") {
           parse(many1(skip1st(char1(','), many1(digit))), src);
       THEN("results [\"123\"]") {
         const char** itr = list_begin(xs);
-        REQUIRE("123" == std::string(itr[0]));
+        REQUIRE(std::string("123") == itr[0]);
         AND_WHEN("apply string1(\",abc\")") {
           THEN("results \",abc\"") {
-            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+            REQUIRE(std::string(",abc") == parse(string1(",abc"), src));
           }
         }
       }

--- a/test/src/test_octDigit.cpp
+++ b/test/src/test_octDigit.cpp
@@ -41,7 +41,7 @@ SCENARIO("octDigit", "[cparsec2][parser][octDigit]") {
     Source src = Source_new("0123456789abcdefg");
     WHEN("apply many1(octDigit)") {
       THEN("reaulst \"01234567\"") {
-        REQUIRE("01234567" == parse(many1(octDigit), src));
+        REQUIRE(std::string("01234567") == parse(many1(octDigit), src));
       }
     }
   }
@@ -49,7 +49,7 @@ SCENARIO("octDigit", "[cparsec2][parser][octDigit]") {
     Source src = Source_new("0123456789ABCDEFG");
     WHEN("apply many1(octDigit)") {
       THEN("reaulst \"01234567\"") {
-        REQUIRE("01234567" == parse(many1(octDigit), src));
+        REQUIRE(std::string("01234567") == parse(many1(octDigit), src));
       }
     }
   }

--- a/test/src/test_seq.cpp
+++ b/test/src/test_seq.cpp
@@ -9,7 +9,8 @@ SCENARIO("seq(letter, digit, digit)", "[cparsec2][parser][seq]") {
     Source src = Source_new("a12");
     WHEN("apply seq(letter, digit, digit)") {
       THEN("results \"a12\"") {
-        REQUIRE("a12" == parse(seq(letter, digit, digit), src));
+        REQUIRE(std::string("a12") ==
+                parse(seq(letter, digit, digit), src));
       }
     }
   }
@@ -17,7 +18,8 @@ SCENARIO("seq(letter, digit, digit)", "[cparsec2][parser][seq]") {
     Source src = Source_new("_123");
     WHEN("apply seq(letter, digit, digit)") {
       THEN("results \"_12\"") {
-        REQUIRE("_12" == parse(seq(letter, digit, digit), src));
+        REQUIRE(std::string("_12") ==
+                parse(seq(letter, digit, digit), src));
       }
     }
   }
@@ -51,9 +53,9 @@ SCENARIO("seq", "[cparsec2][parser][seq]") {
       List(String) xs = parse(seq(x, x, x), src);
       THEN("results [\"123\", \"456\", \"789\"]") {
         const char** itr = list_begin(xs);
-        REQUIRE("123" == std::string(itr[0]));
-        REQUIRE("456" == std::string(itr[1]));
-        REQUIRE("789" == std::string(itr[2]));
+        REQUIRE(std::string("123") == itr[0]);
+        REQUIRE(std::string("456") == itr[1]);
+        REQUIRE(std::string("789") == itr[2]);
       }
     }
   }

--- a/test/src/test_skip.cpp
+++ b/test/src/test_skip.cpp
@@ -48,7 +48,8 @@ SCENARIO("skip", "[cparsec2][parser][skip]") {
         REQUIRE_NOTHROW(parse(skip(number), src));
         AND_WHEN("apply string1(\" 456 789\")") {
           THEN("results \" 456 789\"") {
-            REQUIRE(" 456 789" == parse(string1(" 456 789"), src));
+            REQUIRE(std::string(" 456 789") ==
+                    parse(string1(" 456 789"), src));
           }
         }
       }

--- a/test/src/test_skip1st.cpp
+++ b/test/src/test_skip1st.cpp
@@ -9,19 +9,22 @@ SCENARIO("skip1st", "[cparsec2][parser][skip1st]") {
     Source src = Source_new("abc");
     WHEN("apply skip1st(char1('a'), string1(\"bc\"))") {
       THEN("results \"bc\"") {
-        REQUIRE("bc" == parse(skip1st(char1('a'), string1("bc")), src));
+        REQUIRE(std::string("bc") ==
+                parse(skip1st(char1('a'), string1("bc")), src));
       }
     }
     WHEN("apply skip1st(char1('X'), string1(\"bc\"))") {
       THEN("cause exception(\"expects 'X' but was 'a'\")") {
-        REQUIRE_THROWS_WITH(parse(skip1st(char1('X'), string1("bc")), src),
-                            "expects 'X' but was 'a'");
+        REQUIRE_THROWS_WITH(
+            parse(skip1st(char1('X'), string1("bc")), src),
+            "expects 'X' but was 'a'");
       }
     }
     WHEN("apply skip1st(char1('a'), string1(\"XY\"))") {
       THEN("cause exception(\"expects 'X' but was 'b'\")") {
-        REQUIRE_THROWS_WITH(parse(skip1st(char1('a'), string1("XY")), src),
-                            "expects 'X' but was 'b'");
+        REQUIRE_THROWS_WITH(
+            parse(skip1st(char1('a'), string1("XY")), src),
+            "expects 'X' but was 'b'");
       }
     }
     WHEN("apply skip1st(string1(\"ab\"), char1('c'))") {
@@ -31,14 +34,16 @@ SCENARIO("skip1st", "[cparsec2][parser][skip1st]") {
     }
     WHEN("apply skip1st(string1(\"aX\"), char1('c'))") {
       THEN("cause exception(\"expects 'X' but was 'b'\")") {
-        REQUIRE_THROWS_WITH(parse(skip1st(string1("aX"), char1('c')), src),
-                            "expects 'X' but was 'b'");
+        REQUIRE_THROWS_WITH(
+            parse(skip1st(string1("aX"), char1('c')), src),
+            "expects 'X' but was 'b'");
       }
     }
     WHEN("apply skip1st(string1(\"ab\"), char1('X'))") {
       THEN("cause exception(\"expects 'X' but was 'c'\")") {
-        REQUIRE_THROWS_WITH(parse(skip1st(string1("ab"), char1('X')), src),
-                            "expects 'X' but was 'c'");
+        REQUIRE_THROWS_WITH(
+            parse(skip1st(string1("ab"), char1('X')), src),
+            "expects 'X' but was 'c'");
       }
     }
   }

--- a/test/src/test_spaces.cpp
+++ b/test/src/test_spaces.cpp
@@ -9,7 +9,7 @@ SCENARIO("spaces", "[cparsec2][parser][spaces]") {
     Source src = Source_new("   a");
     WHEN("apply spaces") {
       THEN("results \"   \"") {
-        REQUIRE("   " == parse(spaces, src));
+        REQUIRE(std::string("   ") == parse(spaces, src));
       }
     }
   }
@@ -17,7 +17,7 @@ SCENARIO("spaces", "[cparsec2][parser][spaces]") {
     Source src = Source_new(" \t\n\r");
     WHEN("apply spaces") {
       THEN("results \" \\t\\n\\r\"") {
-        REQUIRE(" \t\n\r" == parse(spaces, src));
+        REQUIRE(std::string(" \t\n\r") == parse(spaces, src));
       }
     }
   }
@@ -25,7 +25,7 @@ SCENARIO("spaces", "[cparsec2][parser][spaces]") {
     Source src = Source_new("a");
     WHEN("apply spaces") {
       THEN("results \"\"") {
-        REQUIRE("" == parse(spaces, src));
+        REQUIRE(std::string("") == parse(spaces, src));
       }
     }
   }
@@ -33,7 +33,7 @@ SCENARIO("spaces", "[cparsec2][parser][spaces]") {
     Source src = Source_new("");
     WHEN("apply spaces") {
       THEN("results \"\"") {
-        REQUIRE("" == parse(spaces, src));
+        REQUIRE(std::string("") == parse(spaces, src));
       }
     }
   }

--- a/test/src/test_string1.cpp
+++ b/test/src/test_string1.cpp
@@ -9,7 +9,7 @@ SCENARIO("string1(str)", "[cparsec2][parser][string1]") {
     Source src = Source_new("a1234");
     WHEN("apply string1(\"a1234\")") {
       THEN("results \"a1234\"") {
-        REQUIRE("a1234" == parse(string1("a1234"), src));
+        REQUIRE(std::string("a1234") == parse(string1("a1234"), src));
       }
     }
   }
@@ -17,7 +17,7 @@ SCENARIO("string1(str)", "[cparsec2][parser][string1]") {
     Source src = Source_new("a1234");
     WHEN("apply string1(\"a123\")") {
       THEN("results \"a123\"") {
-        REQUIRE("a123" == parse(string1("a123"), src));
+        REQUIRE(std::string("a123") == parse(string1("a123"), src));
       }
     }
   }
@@ -25,7 +25,7 @@ SCENARIO("string1(str)", "[cparsec2][parser][string1]") {
     Source src = Source_new("a123bc");
     WHEN("apply string1(\"a123\")") {
       THEN("results \"a123\"") {
-        REQUIRE("a123" == parse(string1("a123"), src));
+        REQUIRE(std::string("a123") == parse(string1("a123"), src));
       }
     }
   }

--- a/test/src/test_token.cpp
+++ b/test/src/test_token.cpp
@@ -10,7 +10,7 @@ SCENARIO("token(many1(digit))", "[cparsec2][parser][token]") {
     WHEN("apply number = token(many1(digit))") {
       StringParser number = token(many1(digit));
       THEN("results \"1234\"") {
-        REQUIRE("1234" == parse(number, src));
+        REQUIRE(std::string("1234") == parse(number, src));
       }
     }
   }
@@ -19,7 +19,7 @@ SCENARIO("token(many1(digit))", "[cparsec2][parser][token]") {
     WHEN("apply number = token(many1(digit))") {
       StringParser number = token(many1(digit));
       THEN("value is \"1\"") {
-        REQUIRE("1" == parse(number, src));
+        REQUIRE(std::string("1") == parse(number, src));
       }
     }
   }
@@ -83,13 +83,13 @@ SCENARIO("token(\"foo\")", "[cparsec2][parser][token]") {
     WHEN("apply foo = token(\"foo\")") {
       StringParser foo = token("foo");
       THEN("results \"foo\"") {
-        REQUIRE("foo" == parse(foo, src));
+        REQUIRE(std::string("foo") == parse(foo, src));
         AND_WHEN("apply foo") {
           THEN("results \"foo\"") {
-            REQUIRE("foo" == parse(foo, src));
+            REQUIRE(std::string("foo") == parse(foo, src));
             AND_WHEN("apply foo") {
               THEN("results \"foo\"") {
-                REQUIRE("foo" == parse(foo, src));
+                REQUIRE(std::string("foo") == parse(foo, src));
                 AND_WHEN("apply foo") {
                   THEN("cause exception(\"expects 'f' but was 'b'\")") {
                     REQUIRE_THROWS_WITH(parse(foo, src),
@@ -126,9 +126,9 @@ SCENARIO("token(PARSER(List(T)))", "[cparsec2][parser][token]") {
       List(String) xs = parse(token(p), src);
       THEN("results [\"123\", \"456\", \"789\"]") {
         const char** itr = list_begin(xs);
-        REQUIRE("123" == std::string(itr[0]));
-        REQUIRE("456" == std::string(itr[1]));
-        REQUIRE("789" == std::string(itr[2]));
+        REQUIRE(std::string("123") == itr[0]);
+        REQUIRE(std::string("456") == itr[1]);
+        REQUIRE(std::string("789") == itr[2]);
       }
     }
   }

--- a/test/src/test_tryp.cpp
+++ b/test/src/test_tryp.cpp
@@ -10,7 +10,7 @@ SCENARIO("tryp(p)", "[cparsec2][parser][tryp]") {
     Source src = Source_new("123");
     WHEN("applied 'tryp(many(digit))'") {
       THEN("resuls \"123\"") {
-        REQUIRE("123" == parse(tryp(many(digit)), src));
+        REQUIRE(std::string("123") == parse(tryp(many(digit)), src));
       }
     }
     WHEN("applied 'tryp(char1('a'))'") {
@@ -30,13 +30,13 @@ SCENARIO("tryp(p)", "[cparsec2][parser][tryp]") {
     WHEN("an input was \"ab\"") {
       Source src = Source_new("ab");
       THEN("applied 'p' results \"ab\"") {
-        REQUIRE("ab" == parse(p, src));
+        REQUIRE(std::string("ab") == parse(p, src));
       }
     }
     WHEN("an input was \"bc\"") {
       Source src = Source_new("bc");
       THEN("applied 'p' results \"bc\"") {
-        REQUIRE("bc" == parse(p, src));
+        REQUIRE(std::string("bc") == parse(p, src));
       }
     }
     WHEN("an input was \"ac\"") {
@@ -84,9 +84,9 @@ SCENARIO("tryp(PARSER(List(T)))", "[cparsec2][parser][tryp]") {
       List(String) xs = parse(tryp(p), src);
       THEN("results [\"123\", \"456\", \"789\"]") {
         const char** itr = list_begin(xs);
-        REQUIRE("123" == std::string(itr[0]));
-        REQUIRE("456" == std::string(itr[1]));
-        REQUIRE("789" == std::string(itr[2]));
+        REQUIRE(std::string("123") == itr[0]);
+        REQUIRE(std::string("456") == itr[1]);
+        REQUIRE(std::string("789") == itr[2]);
       }
     }
   }
@@ -98,18 +98,19 @@ SCENARIO("tryp(PARSER(List(T)))", "[cparsec2][parser][tryp]") {
                             "not satisfy");
         AND_WHEN("apply string1(\",abc\")") {
           THEN("results \",abc\"") {
-            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+            REQUIRE(std::string(",abc") == parse(string1(",abc"), src));
           }
         }
       }
     }
     WHEN("apply tryp(skip1st(char1(','), many1(digit)))") {
       THEN("cause exception(\"not satisfy\")") {
-        REQUIRE_THROWS_WITH(parse(tryp(skip1st(char1(','), many1(digit))), src),
-                            "not satisfy");
+        REQUIRE_THROWS_WITH(
+            parse(tryp(skip1st(char1(','), many1(digit))), src),
+            "not satisfy");
         AND_WHEN("apply string1(\",abc\")") {
           THEN("results \",abc\"") {
-            REQUIRE(",abc" == std::string(parse(string1(",abc"), src)));
+            REQUIRE(std::string(",abc") == parse(string1(",abc"), src));
           }
         }
       }


### PR DESCRIPTION
refactored `parse()` and `PARSE_TEST()`
- `parse()` invokes type-safe `PARSE(T)()` via `_Generic` (C11) or overloaded function (C++)
- `PARSE_TEST()` invokes type-safe `PARSETEST(T)()` via _Generic (C11) or overloaded function (C++)

And fixed some test cases about comparing string with return value of `PARSER(String)`.