### PR TITLE
example/excc/refactor infix op

### DIFF
--- a/example/excc/src/main.c
+++ b/example/excc/src/main.c
@@ -75,15 +75,18 @@ void add_keyword(const char* s) {
 static PARSER(String) keyword(const char* word);
 
 // program  = {stmt} endOfFile
-// stmt     = expr ";" {expr ";"}
+// stmt     = expr ";"
+//          | "for" "(" [expr] ";" [expr] ";" [expr] ")" stmt
+//          | "while" "(" expr ")" stmt
+//          | "if" "(" expr ")" stmt ["else" stmt]
 // expr     = assign
-// assign   = equality {"=" assign}
+// assign   = equality {"=" equality}
 // equality = relation {("==" | "!=") relation}
 // relation = addsub {("<" | "<=" | ">" | ">=") addsub}
 // addsub   = muldiv { ("+" | "-") muldiv }
 // muldiv   = unary { ("*" | "/") unary }
 // unary    = ["+" | "-"] term
-// term     = number | "(" expr ")"
+// term     = number | "(" expr ")" | ident
 PARSER(List(Node)) program;
 PARSER(Node) stmt;
 PARSER(Node) expr;

--- a/example/excc/tests.sh
+++ b/example/excc/tests.sh
@@ -70,6 +70,11 @@ assert 0 = ${CMD} ' 99 >= 100;'
 assert 10 = ${CMD} 'a = 10;'
 assert 20 = ${CMD} 'a = b = 10; a+b;'
 assert 30 = ${CMD} 'a = b = 10; b = b + 10; a + b;'
+assert "error:lvalue of assignment is not a variable" \
+       = ${CMD} '1 + 9 = 10;'
+assert "error:lvalue of assignment is not a variable" \
+       = ${CMD} '1 + a = 9 == 10;'
+assert 1 = ${CMD} '1 + (a = 9) == 10;'
 assert 30 = ${CMD} 'abc1 = _bcd32 = 10; 2 * abc1 + _bcd32;'
 assert 15 = ${CMD} 'return 15;'
 assert 15 = ${CMD} 'a = 10; return a+5;'

--- a/include/cparsec2/codegen.h
+++ b/include/cparsec2/codegen.h
@@ -30,6 +30,8 @@ Node nd_EQ(Node lhs, Node rhs);
 Node nd_NE(Node lhs, Node rhs);
 Node nd_LT(Node lhs, Node rhs);
 Node nd_LE(Node lhs, Node rhs);
+Node nd_GT(Node lhs, Node rhs);
+Node nd_GE(Node lhs, Node rhs);
 Node nd_add(Node lhs, Node rhs);
 Node nd_sub(Node lhs, Node rhs);
 Node nd_mul(Node lhs, Node rhs);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -241,6 +241,12 @@ Node nd_LT(Node lhs, Node rhs) {
 Node nd_LE(Node lhs, Node rhs) {
   return infix(run_nd_LE, lhs, rhs);
 }
+Node nd_GT(Node lhs, Node rhs) {
+  return infix(run_nd_LT, rhs, lhs);
+}
+Node nd_GE(Node lhs, Node rhs) {
+  return infix(run_nd_LE, rhs, lhs);
+}
 Node nd_add(Node lhs, Node rhs) {
   return infix(run_nd_add, lhs, rhs);
 }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -150,7 +150,7 @@ Node nd_c_compound_stmt(int n, Node* block) {
 static void run_nd_assign(void* arg, FILE* out) {
   Node* node = (Node*)arg;
   if (node[0]->run != run_nd_lvar) {
-    fprintf(stderr, "lvalue of assignment is not a variable");
+    fprintf(stderr, "error:lvalue of assignment is not a variable");
     exit(1);
   }
   int* lvar = node[0]->arg;


### PR DESCRIPTION
replaced all binary operator parser with the following parser-combinators.
- `infixl` (infix, left associative)
- `infixr` (infix, right associative)