### PR TITLE
Feature/parse error

### DIFF
--- a/example/calc/tests.sh
+++ b/example/calc/tests.sh
@@ -2,6 +2,10 @@
 
 CMD=./bin/calc
 
+replace_newline_with_linefeed () {
+    sed -E -e 's/(\r|\r\n|\n)/\n/g'
+}
+
 pass=0
 fail=0
 
@@ -9,7 +13,7 @@ assert() {
     expect=$1
     op=$2
     shift 2
-    actual=$("$@")
+    actual=$("$@" | replace_newline_with_linefeed)
     test "$expect" "$op" "$actual" || {
         echo "[FAIL] $expect $op $@"
         echo "    expects \"$expect\""
@@ -35,7 +39,10 @@ assert 17 = ${CMD} '10 / 2 + 4 * 3'
 assert  5 = ${CMD} '-1+2*3'
 assert  9 = ${CMD} '-(1+2)*-3'
 assert  9 = ${CMD} '(-1 + -2) * -3'
-assert "error:expects <eof> but was ';'" = ${CMD} '1+2;'
+assert "error:expects <endOfFile> but was ';'
+Parse error:3
+  unexpected ';'
+  expecting <endOfFile>" = ${CMD} '1+2;'
 
 echo
 echo "$((pass + fail)) tests, $pass passed, $fail failed"

--- a/example/calcc/src/main.c
+++ b/example/calcc/src/main.c
@@ -113,9 +113,9 @@ int main(int argc, char** argv) {
 
   setup();
 
+  Source src = Source_new(argv[1]);
   Ctx ctx;
   TRY(&ctx) {
-    Source src = Source_new(argv[1]);
     Node ast = parse(skip2nd(expr, token(endOfFile)), src, &ctx);
 
     // [generate assembly code]
@@ -132,6 +132,7 @@ int main(int argc, char** argv) {
   }
   else {
     fprintf(stderr, "error:%s\n", ctx.msg);
+    fprintf(stderr, "%s\n", getParseErrorAsString(src));
     return 1;
   }
 }

--- a/example/calcc/tests.sh
+++ b/example/calcc/tests.sh
@@ -3,6 +3,10 @@
 CMD=./bin/calcc
 CC=${CC:-gcc}
 
+replace_newline_with_linefeed () {
+    sed -E -e 's/(\r|\r\n|\n)/\n/g'
+}
+
 compile_and_run() {
     "$@" > tmp.s 2> err.log || {
         cat err.log
@@ -20,7 +24,7 @@ assert() {
     expect=$1
     op=$2
     shift 2
-    actual=$(compile_and_run "$@")
+    actual=$(compile_and_run "$@" | replace_newline_with_linefeed)
     rm -f tmp tmp.s err.log
     test "$expect" "$op" "$actual" || {
         echo "[FAIL] $expect $op $@"
@@ -47,7 +51,10 @@ assert 17 = ${CMD} '10 / 2 + 4 * 3'
 assert  5 = ${CMD} '-1+2*3'
 assert  9 = ${CMD} '-(1+2)*-3'
 assert  9 = ${CMD} '(-1 + -2) * -3'
-assert "error:expects <eof> but was ';'" = ${CMD} '1+2;'
+assert "error:expects <endOfFile> but was ';'
+Parse error:3
+  unexpected ';'
+  expecting <endOfFile>" = ${CMD} '1+2;'
 
 echo
 echo "$((pass + fail)) tests, $pass passed, $fail failed"

--- a/example/excc/src/main.c
+++ b/example/excc/src/main.c
@@ -423,10 +423,10 @@ int main(int argc, char** argv) {
 
   setup();
 
+  Source src = Source_new(argv[1]);
   Ctx ctx;
   TRY(&ctx) {
     FILE* out = stdout;
-    Source src = Source_new(argv[1]);
     Node ast = parse(program, src, &ctx);
 
     // [generate assembly code]
@@ -436,6 +436,7 @@ int main(int argc, char** argv) {
   }
   else {
     fprintf(stderr, "error:%s\n", ctx.msg);
+    fprintf(stderr, "%s\n", getParseErrorAsString(src));
     return 1;
   }
 }

--- a/example/excc/tests.sh
+++ b/example/excc/tests.sh
@@ -53,7 +53,11 @@ assert 17 = ${CMD} 'main() { 10 / 2 + 4 * 3; }'
 assert  5 = ${CMD} 'main() { -1+2*3; }'
 assert  9 = ${CMD} 'main() { -(1+2)*-3; }'
 assert  9 = ${CMD} 'main() { (-1 + -2) * -3; }'
-assert "error:expects <eof> but was '$'" = ${CMD} 'main() { 1+2; } $'
+assert "error:expects <endOfFile> but was '$'
+Parse error:16
+  unexpected '$'
+  expecting <endOfFile>" \
+       = ${CMD} 'main() { 1+2; } $'
 assert 13 = ${CMD} 'main() { 14; 2+11; }'
 assert 1 = ${CMD} 'main() { 100 == 100; }'
 assert 0 = ${CMD} 'main() { 101 == 100; }'
@@ -84,10 +88,16 @@ assert 15 = ${CMD} 'main() { return 15; }'
 assert 15 = ${CMD} 'main() { a = 10; return a+5; }'
 assert 15 = ${CMD} 'main() { a = 10; return 15; a; }'
 assert 15 = ${CMD} 'main() { return+15; }'
-assert "error:expects '}' but was 'r'" \
+assert "error:expects '}' but was 'r'
+Parse error:9
+  unexpected 'r'
+  expecting '}'" \
        = ${CMD} 'main() { return; }'
 assert 15 = ${CMD} 'main() { returnx=15; }'
-assert "error:expects '}' but was 'r'" \
+assert "error:expects '}' but was 'r'
+Parse error:9
+  unexpected 'r'
+  expecting '}'" \
        = ${CMD} 'main() { return=15; }'
 assert 45 = ${CMD} '
 main() {

--- a/include/cparsec2.h
+++ b/include/cparsec2.h
@@ -61,7 +61,13 @@ PARSER(String) utf8(const char* s);
 // ---- parser combinators ----
 
 // Parser<T> expects(const char* desc, Parser<T> p);
-PARSER(Char) expects(const char* desc, PARSER(Char) p); // TODO test
+// TODO test
+#define EXPECTS(T) CAT(expects_, T)
+#define DECLARE_EXPECTS(T)                                               \
+  PARSER(T) EXPECTS(T)(const char* desc, PARSER(T) p)
+FOREACH(DECLARE_EXPECTS, TYPESET(1));
+#define expects(desc, p)                                                 \
+  (GENERIC_P(PARSER_CAST(p), EXPECTS, TYPESET(1))((desc), PARSER_CAST(p)))
 
 // Parser<T[]> many(Parser<T> p);
 #define MANY(T) CAT(many_, T)

--- a/include/cparsec2.hpp
+++ b/include/cparsec2.hpp
@@ -55,6 +55,17 @@ FOREACH(DEFINE_CXX_PARSE, TYPESET(1));
 FOREACH(DEFINE_CXX_PARSETEST, TYPESET(1));
 #endif
 
+#ifdef expects
+#undef expects
+#define expects(desc, p) cxx_expects((desc), parser_cast(p))
+#define DEFINE_CXX_EXPECTS(T)                                            \
+  inline auto cxx_expects(const char* desc, PARSER(T) p) {               \
+    return EXPECTS(T)(desc, p);                                          \
+  }                                                                      \
+  END_OF_STATEMENTS
+FOREACH(DEFINE_CXX_EXPECTS, TYPESET(1));
+#endif
+
 #ifdef many
 #undef many
 #define many(p) cxx_many(parser_cast(p))

--- a/include/cparsec2/parseerror.h
+++ b/include/cparsec2/parseerror.h
@@ -1,0 +1,71 @@
+/* -*- coding:utf-8-unix -*- */
+#pragma once
+
+#include <stdbool.h>
+
+#include "sourcepos.h"
+
+#include "macros.h"
+
+#include "list.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum ErrMsgType {
+  SysUnexpect = 0,
+  Unexpect = 1,
+  Expect = 2,
+  Message = 3,
+};
+
+typedef struct ErrMsgSt {
+  enum ErrMsgType type;
+  const char* msg;
+} ErrMsg;
+
+TYPEDEF_LIST(ErrMsg, ErrMsg);
+DECLARE_LIST(ErrMsg);
+
+TYPEDEF_BUFF(ErrMsg, ErrMsg);
+DECLARE_BUFF(ErrMsg);
+
+typedef struct {
+  SourcePos pos;
+  List(ErrMsg) msgs;
+} ParseError;
+
+/** Gets the source-position of the ParseError `e` */
+SourcePos ParseError_getPos(ParseError e);
+/** Sets the source-position to the ParseError `e` */
+ParseError ParseError_setPos(SourcePos pos, ParseError e);
+/** Returns list of messages in the ParseError `e` */
+List(ErrMsg) ParseError_getMessages(ParseError e);
+/** Tests whether the ParseError has no message */
+bool ParseError_isUnknown(ParseError e);
+/** Constructs a ParseError without message */
+ParseError ParseError_new(SourcePos pos);
+/** Add `msg` to the ParseError `e` */
+ParseError ParseError_addMessage(ErrMsg msg, ParseError e);
+/** Remove same type messages from `e` and add `msg` to `e` */
+ParseError ParseError_setMessage(ErrMsg msg, ParseError e);
+/**
+ * Merges two errors or select one.
+ *
+ * - Merges two errors if both source-position were same,
+ * - otherwise returns one who has larger source-position.
+ */
+ParseError ParseError_merge(ParseError e1, ParseError e2);
+
+/**
+ * Construct formatted error message string.
+ */
+const char* ParseError_toString(ParseError e);
+
+/** Tests whether two ParseError have same value */
+bool ParseError_isEqual(ParseError e1, ParseError e2);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/cparsec2/parser.h
+++ b/include/cparsec2/parser.h
@@ -2,8 +2,8 @@
 #pragma once
 
 #include <assert.h>
-#include <stdio.h>
 #include <stdbool.h>
+#include <stdio.h>
 
 // ---- resource management ----
 #include "alloc.h"
@@ -68,6 +68,7 @@
     else {                                                               \
       printf("error:%s\n", ctx.msg);                                     \
       mem_free((void*)ctx.msg);                                          \
+      printf("%s\n", getParseErrorAsString(src));                        \
       return false;                                                      \
     }                                                                    \
   }                                                                      \

--- a/include/cparsec2/source.h
+++ b/include/cparsec2/source.h
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 
 #include "exception.h"
+#include "parseerror.h"
 #include "sourcepos.h"
 
 #ifdef __cplusplus
@@ -35,6 +36,12 @@ void consume(Source src);
 SourcePos getSourcePos(Source src);
 // set current souce position (revert state of the source)
 void setSourcePos(Source src, SourcePos pos);
+
+const char* getParseErrorAsString(Source src);
+ParseError getParseError(Source src);
+void setParseError(Source src, ParseError err);
+
+void parseError(Source src, ErrMsg msg);
 
 #ifdef __cplusplus
 }

--- a/src/builtin_parsers.c
+++ b/src/builtin_parsers.c
@@ -42,7 +42,7 @@ static int number_fn(void* arg, Source src, Ctx* ex) {
 }
 
 static void cparsec2_init__stage1(void) {
-  anyChar = satisfy(is_anyChar);
+  anyChar = expects("a character", satisfy(is_anyChar));
   digit = expects("a decimal digit", satisfy(is_digit));
   hexDigit = expects("a hexa-decimal digit", satisfy(is_hexDigit));
   octDigit = expects("an octal digit", satisfy(is_octDigit));
@@ -55,13 +55,15 @@ static void cparsec2_init__stage1(void) {
 }
 
 static void cparsec2_init__stage2(void) {
-  spaces = many(space);
+  spaces = expects("zero or more white-spaces", many(space));
   newline = expects("<LF>", char1('\n'));
   crlf = expects("<CR><LF>", skip1st(char1('\r'), newline));
   endOfLine = expects("<endOfLine>", either(newline, crlf));
-  endOfFile = expects("<endOfFile>", PARSER_GEN(Char)(endOfFile_fn, NULL));
+  endOfFile =
+      expects("<endOfFile>", PARSER_GEN(Char)(endOfFile_fn, NULL));
   tab = expects("a TAB", char1('\t'));
-  number = PARSER_GEN(Int)(number_fn, token(many1(digit)));
+  number = expects("a number",
+                   PARSER_GEN(Int)(number_fn, token(many1(digit))));
 }
 
 static void cparsec2_init__stage3(void) {
@@ -75,8 +77,9 @@ static void cparsec2_init__stage3(void) {
   PARSER(String) u4a = seq(char1((char)0xF0), range(0x90, 0xBF), t, t);
   PARSER(String) u4b = seq(range(0xF1, 0xF3), t, t, t);
   PARSER(String) u4c = seq(char1((char)0xF4), range(0x80, 0xBF), t, t);
-  anyUtf8 = TREE_FOLDL(EITHER(String), u1, u2, u3a, u3b, u3c, u3d, u4a,
-                       u4b, u4c);
+  anyUtf8 = expects("a UTF-8 character",
+                    TREE_FOLDL(EITHER(String), u1, u2, u3a, u3b, u3c, u3d,
+                               u4a, u4b, u4c));
 }
 
 void cparsec2_create_builtin_parsers(void) {

--- a/src/builtin_parsers.c
+++ b/src/builtin_parsers.c
@@ -43,24 +43,24 @@ static int number_fn(void* arg, Source src, Ctx* ex) {
 
 static void cparsec2_init__stage1(void) {
   anyChar = satisfy(is_anyChar);
-  digit = satisfy(is_digit);
-  hexDigit = satisfy(is_hexDigit);
-  octDigit = satisfy(is_octDigit);
-  lower = satisfy(is_lower);
-  upper = satisfy(is_upper);
-  alpha = satisfy(is_alpha);
-  alnum = satisfy(is_alnum);
-  letter = satisfy(is_letter);
-  space = satisfy(is_space);
+  digit = expects("a decimal digit", satisfy(is_digit));
+  hexDigit = expects("a hexa-decimal digit", satisfy(is_hexDigit));
+  octDigit = expects("an octal digit", satisfy(is_octDigit));
+  lower = expects("a lower-case character", satisfy(is_lower));
+  upper = expects("a upper-case character", satisfy(is_upper));
+  alpha = expects("an alphabet", satisfy(is_alpha));
+  alnum = expects("an alphabet or a decimal digit", satisfy(is_alnum));
+  letter = expects("a letter", satisfy(is_letter));
+  space = expects("one of a white-space", satisfy(is_space));
 }
 
 static void cparsec2_init__stage2(void) {
   spaces = many(space);
-  newline = char1('\n');
-  crlf = skip1st(char1('\r'), newline);
+  newline = expects("<LF>", char1('\n'));
+  crlf = expects("<CR><LF>", skip1st(char1('\r'), newline));
   endOfLine = expects("<endOfLine>", either(newline, crlf));
-  endOfFile = PARSER_GEN(Char)(endOfFile_fn, NULL);
-  tab = char1('\t');
+  endOfFile = expects("<endOfFile>", PARSER_GEN(Char)(endOfFile_fn, NULL));
+  tab = expects("a TAB", char1('\t'));
   number = PARSER_GEN(Int)(number_fn, token(many1(digit)));
 }
 

--- a/src/char1.c
+++ b/src/char1.c
@@ -2,22 +2,32 @@
 
 #include "cparsec2.h"
 
-static char run_char1(void* arg, Source src, Ctx* ex) {
-  char expected = (char)(intptr_t)arg;
-  Ctx ctx;
-  TRY(&ctx) {
-    char c = peek(src, &ctx);
-    if (expected == c) {
-      consume(src);
-      return c;
-    }
-    cthrow(&ctx, error("expects '%c' but was '%c'", expected, c));
-  }
-  else {
-    cthrow(ex, ctx.msg);
+static const char* c2s(uint8_t c) {
+  switch (c) {
+  case '\n':
+    return "'\\n'";
+  case '\r':
+    return "'\\r'";
+  case '\t':
+    return "'\\t'";
+  case ' ':
+    return "' '";
+  default:
+    return mem_printf("'%c'", c);
   }
 }
 
+static char run_char1(void* arg, Source src, Ctx* ex) {
+  char expected = (char)(intptr_t)arg;
+  char c = peek(src, ex);
+  if (expected == c) {
+    consume(src);
+    return c;
+  }
+  parseError(src, (ErrMsg){Unexpect, c2s(c)});
+  cthrow(ex, error("expects %s but was %s", c2s(expected), c2s(c)));
+}
+
 PARSER(Char) char1(char c) {
-  return PARSER_GEN(Char)(run_char1, (void*)(intptr_t)c);
+  return expects(c2s(c), PARSER_GEN(Char)(run_char1, (void*)(intptr_t)c));
 }

--- a/src/either.c
+++ b/src/either.c
@@ -16,7 +16,13 @@
       cthrow(ex, ctx.msg);                                               \
     }                                                                    \
     mem_free((void*)ctx.msg);                                            \
-    return parse(p[1], src, ex);                                         \
+    ParseError err1 = getParseError(src);                                \
+    TRY(&ctx) {                                                          \
+      return parse(p[1], src, &ctx);                                     \
+    }                                                                    \
+    ParseError err2 = getParseError(src);                                \
+    setParseError(src, ParseError_merge(err1, err2));                    \
+    cthrow(ex, ctx.msg);                                                 \
   }                                                                      \
   PARSER(T) EITHER(T)(PARSER(T) p1, PARSER(T) p2) {                      \
     PARSER(T)* arg = mem_malloc(sizeof(PARSER(T)[2]));                   \

--- a/src/expects.c
+++ b/src/expects.c
@@ -4,29 +4,36 @@
 
 #include <cparsec2.h>
 
-static char expects_fn(void* arg, Source src, Ctx* ex) {
-  void** ps = (void**)arg;
-  const char* desc = ps[0];
-  CharParser p = ps[1];
-  Ctx ctx;
-  TRY(&ctx) {
-    return parse(p, src, &ctx);
-  }
-  else {
-    ErrMsg m = {Expect, desc};
-    parseError(src, m);
-    const char* bw = strstr(ctx.msg, "but was");
-    if (bw) {
-      cthrow(ex, error("expects %s %s", desc, bw));
-    } else {
-      cthrow(ex, ctx.msg);
-    }
-  }
-}
+#define EXPECTS_FN(T) CAT(run_expects, T)
+#define DEFINE_EXPECTS(T)                                                \
+  static RETURN_TYPE(PARSER(T))                                          \
+      EXPECTS_FN(T)(void* arg, Source src, Ctx* ex) {                    \
+    void** ps = (void**)arg;                                             \
+    const char* desc = ps[0];                                            \
+    PARSER(T) p = ps[1];                                                 \
+    Ctx ctx;                                                             \
+    TRY(&ctx) {                                                          \
+      return parse(p, src, &ctx);                                        \
+    }                                                                    \
+    else {                                                               \
+      ErrMsg m = {Expect, desc};                                         \
+      parseError(src, m);                                                \
+      const char* bw = strstr(ctx.msg, "but was");                       \
+      if (bw) {                                                          \
+        const char* msg = error("expects %s %s", desc, bw);              \
+        mem_free((void*)ctx.msg);                                        \
+        cthrow(ex, msg);                                                 \
+      } else {                                                           \
+        cthrow(ex, ctx.msg);                                             \
+      }                                                                  \
+    }                                                                    \
+  }                                                                      \
+  PARSER(T) EXPECTS(T)(const char* desc, PARSER(T) p) {                  \
+    void** ps = mem_malloc(sizeof(void*) * 2);                           \
+    ps[0] = (void*)desc;                                                 \
+    ps[1] = (void*)p;                                                    \
+    return PARSER_GEN(T)(EXPECTS_FN(T), ps);                             \
+  }                                                                      \
+  END_OF_STATEMENTS
 
-CharParser expects(const char* desc, CharParser p) {
-  void** ps = mem_malloc(sizeof(void*) * 2);
-  ps[0] = (void*)desc;
-  ps[1] = (void*)p;
-  return PARSER_GEN(Char)(expects_fn, ps);
-}
+FOREACH(DEFINE_EXPECTS, TYPESET(1));

--- a/src/expects.c
+++ b/src/expects.c
@@ -13,6 +13,8 @@ static char expects_fn(void* arg, Source src, Ctx* ex) {
     return parse(p, src, &ctx);
   }
   else {
+    ErrMsg m = {Expect, desc};
+    parseError(src, m);
     const char* bw = strstr(ctx.msg, "but was");
     if (bw) {
       cthrow(ex, error("expects %s %s", desc, bw));

--- a/src/parseerror.c
+++ b/src/parseerror.c
@@ -78,13 +78,13 @@ static const char* format_msgs(const char* prefix, List(String) msgs) {
     if (itr != end) {
       buff_append(&b, *itr++);
     }
-    for (; itr < end - 1; ++itr) {
+    while (itr < end - 1) {
       buff_append(&b, ", ");
-      buff_append(&b, *itr);
+      buff_append(&b, *itr++);
     }
     if (itr != end) {
       buff_append(&b, ", or ");
-      buff_append(&b, *itr);
+      buff_append(&b, *itr++);
     }
     buff_append(&b, "\n");
   }

--- a/src/parseerror.c
+++ b/src/parseerror.c
@@ -1,0 +1,149 @@
+/* -*- coding:utf-8-unix -*- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <string.h>
+
+#include "cparsec2/alloc.h"
+#include "cparsec2/parseerror.h"
+
+DEFINE_LIST(ErrMsg);
+DEFINE_BUFF(ErrMsg);
+
+/** Gets the source-position of the ParseError `e` */
+SourcePos ParseError_getPos(ParseError e) {
+  return e.pos;
+}
+/** Sets the source-position to the ParseError `e` */
+ParseError ParseError_setPos(SourcePos pos, ParseError e) {
+  return (ParseError){.pos = pos, .msgs = e.msgs};
+}
+/** Returns list of messages in the ParseError `e` */
+List(ErrMsg) ParseError_getMessages(ParseError e) {
+  return e.msgs;
+}
+/** Tests whether the ParseError has no message */
+bool ParseError_isUnknown(ParseError e) {
+  return LIST_LENGTH(ErrMsg)(e.msgs) == 0;
+}
+/** Constructs a ParseError without message */
+ParseError ParseError_new(SourcePos pos) {
+  return (ParseError){.pos = pos, .msgs = (List(ErrMsg)){0}};
+}
+/** Add `msg` to the ParseError `e` */
+ParseError ParseError_addMessage(ErrMsg msg, ParseError e) {
+  Buff(ErrMsg) b = {0};
+  BUFF_APPEND(ErrMsg)(&b, e.msgs);
+  BUFF_PUSH(ErrMsg)(&b, msg);
+  return (ParseError){.pos = e.pos, .msgs = BUFF_FINISH(ErrMsg)(&b)};
+}
+/** Remove same type messages from `e` and add `msg` to `e` */
+ParseError ParseError_setMessage(ErrMsg msg, ParseError e) {
+  Buff(ErrMsg) b = {0};
+  BUFF_PUSH(ErrMsg)(&b, msg);
+  ErrMsg* itr = LIST_BEGIN(ErrMsg)(e.msgs);
+  ErrMsg* end = LIST_END(ErrMsg)(e.msgs);
+  for (; itr != end; ++itr) {
+    if (msg.type != itr->type) {
+      BUFF_PUSH(ErrMsg)(&b, *itr);
+    }
+  }
+  return (ParseError){.pos = e.pos, .msgs = BUFF_FINISH(ErrMsg)(&b)};
+}
+/**
+ * Merges two errors or select one.
+ *
+ * - Merges two errors if both source-position were same,
+ * - otherwise returns one who has larger source-position.
+ */
+ParseError ParseError_merge(ParseError e1, ParseError e2) {
+  if (e1.pos.offset > e2.pos.offset) {
+    return e1;
+  }
+  if (e1.pos.offset < e2.pos.offset) {
+    return e2;
+  }
+  Buff(ErrMsg) b = {0};
+  BUFF_APPEND(ErrMsg)(&b, e1.msgs);
+  BUFF_APPEND(ErrMsg)(&b, e2.msgs);
+  return (ParseError){.pos = e1.pos, .msgs = BUFF_FINISH(ErrMsg)(&b)};
+}
+
+static const char* format_msgs(const char* prefix, List(String) msgs) {
+  Buff(Char) b = {0};
+  if (0 < list_length(msgs)) {
+    buff_append(&b, mem_printf("%s ", prefix));
+    const char** itr = list_begin(msgs);
+    const char** end = list_end(msgs);
+    if (itr != end) {
+      buff_append(&b, *itr++);
+    }
+    for (; itr < end - 1; ++itr) {
+      buff_append(&b, ", ");
+      buff_append(&b, *itr);
+    }
+    if (itr != end) {
+      buff_append(&b, ", or ");
+      buff_append(&b, *itr);
+    }
+    buff_append(&b, "\n");
+  }
+  return buff_finish(&b);
+}
+
+/**
+ * Construct formatted error message string.
+ */
+const char* ParseError_toString(ParseError e) {
+  Buff(Char) b = {0};
+  buff_append(&b, mem_printf("Parse error:%" PRIdMAX "\n",
+                             (intmax_t)e.pos.offset));
+  if (ParseError_isUnknown(e)) {
+    buff_append(&b, mem_printf("  unknown error\n"));
+  } else {
+    Buff(String) mUnexpect = {0};
+    Buff(String) mExpect = {0};
+    Buff(String) mMessage = {0};
+    ErrMsg* itr = LIST_BEGIN(ErrMsg)(e.msgs);
+    ErrMsg* end = LIST_END(ErrMsg)(e.msgs);
+    for (; itr != end; ++itr) {
+      switch (itr->type) {
+      case SysUnexpect:
+      case Unexpect:
+        buff_push(&mUnexpect, itr->msg);
+        break;
+      case Expect:
+        buff_push(&mExpect, itr->msg);
+        break;
+      case Message:
+        buff_push(&mMessage, itr->msg);
+        break;
+      default:
+        assert(0 && "invalid message type");
+      }
+    }
+    buff_append(&b, format_msgs("  unexpected", buff_finish(&mUnexpect)));
+    buff_append(&b, format_msgs("  expecting", buff_finish(&mExpect)));
+    buff_append(&b, format_msgs("  ", buff_finish(&mMessage)));
+  }
+  return buff_finish(&b);
+}
+
+/** Tests whether two ParseError have same value */
+bool ParseError_isEqual(ParseError e1, ParseError e2) {
+  if (!isSourcePosEqual(e1.pos, e2.pos)) {
+    return false;
+  }
+  if (LIST_LENGTH(ErrMsg)(e1.msgs) != LIST_LENGTH(ErrMsg)(e2.msgs)) {
+    return false;
+  }
+  ErrMsg* itr1 = LIST_BEGIN(ErrMsg)(e1.msgs);
+  ErrMsg* end1 = LIST_END(ErrMsg)(e1.msgs);
+  ErrMsg* itr2 = LIST_BEGIN(ErrMsg)(e2.msgs);
+  for (; itr1 != end1; ++itr1, ++itr2) {
+    if (itr1->type != itr2->type || strcmp(itr1->msg, itr2->msg)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/satisfy.c
+++ b/src/satisfy.c
@@ -15,6 +15,8 @@ static char run_satisfy(void* arg, Source src, Ctx* ex) {
       consume(src);
       return c;
     }
+    ErrMsg m = {Unexpect, mem_printf("'%c'", c)};
+    parseError(src, m);
     cthrow(&ctx, error("not satisfy"));
   }
   else {

--- a/src/string1.c
+++ b/src/string1.c
@@ -4,22 +4,15 @@
 
 static const char* run_string1(void* arg, Source src, Ctx* ex) {
   const char* expected = (const char*)arg;
-  Ctx ctx;
-  TRY(&ctx) {
-    const char* p = expected;
-    while (*p) {
-      parse(char1(*p), src, &ctx);
-      p++;
-    }
-    return expected;
+  const char* p = expected;
+  while (*p) {
+    parse(char1(*p), src, ex);
+    p++;
   }
-  else {
-    ErrMsg m = {Expect, mem_printf("\"%s\"", expected)};
-    parseError(src, m);
-    cthrow(ex, ctx.msg);
-  }
+  return expected;
 }
 
 PARSER(String) string1(const char* s) {
-  return PARSER_GEN(String)(run_string1, (void*)s);
+  return expects(mem_printf("\"%s\"", s),
+                 PARSER_GEN(String)(run_string1, (void*)s));
 }

--- a/src/string1.c
+++ b/src/string1.c
@@ -14,6 +14,8 @@ static const char* run_string1(void* arg, Source src, Ctx* ex) {
     return expected;
   }
   else {
+    ErrMsg m = {Expect, mem_printf("\"%s\"", expected)};
+    parseError(src, m);
     cthrow(ex, ctx.msg);
   }
 }

--- a/test/src/test_crlf.cpp
+++ b/test/src/test_crlf.cpp
@@ -8,16 +8,18 @@ SCENARIO("crlf", "[cparsec2][parser][crlf]") {
   GIVEN("an input: \" \" (i.e. SPC)") {
     Source src = Source_new(" ");
     WHEN("apply crlf") {
-      THEN("cause exception(\"expects '\\r' but was ' '\")") {
-        REQUIRE_THROWS_WITH(parse(crlf, src), "expects '\r' but was ' '");
+      THEN("cause exception(\"expects <CR><LF> but was ' '\")") {
+        REQUIRE_THROWS_WITH(parse(crlf, src),
+                            "expects <CR><LF> but was ' '");
       }
     }
   }
   GIVEN("an input: \"\\t\" (i.e. TAB)") {
     Source src = Source_new("\t");
     WHEN("apply crlf") {
-      THEN("cause exception(\"expects '\\r' but was '\\t'\")") {
-        REQUIRE_THROWS_WITH(parse(crlf, src), "expects '\r' but was '\t'");
+      THEN("cause exception(\"expects <CR><LF> but was '\\t'\")") {
+        REQUIRE_THROWS_WITH(parse(crlf, src),
+                            "expects <CR><LF> but was '\\t'");
       }
     }
   }
@@ -32,8 +34,9 @@ SCENARIO("crlf", "[cparsec2][parser][crlf]") {
   GIVEN("an input: \"\\n\" (i.e. LF)") {
     Source src = Source_new("\n");
     WHEN("apply crlf") {
-      THEN("cause exception(\"expects '\\r' but was '\\n'\")") {
-        REQUIRE_THROWS_WITH(parse(crlf, src), "expects '\r' but was '\n'");
+      THEN("cause exception(\"expects <CR><LF> but was '\\n'\")") {
+        REQUIRE_THROWS_WITH(parse(crlf, src),
+                            "expects <CR><LF> but was '\\n'");
       }
     }
   }
@@ -48,8 +51,9 @@ SCENARIO("crlf", "[cparsec2][parser][crlf]") {
   GIVEN("an input: \"a\"") {
     Source src = Source_new("a");
     WHEN("apply crlf") {
-      THEN("cause exception(\"expects '\\r' but was 'a'\")") {
-        REQUIRE_THROWS_WITH(parse(crlf, src), "expects '\r' but was 'a'");
+      THEN("cause exception(\"expects <CR><LF> but was 'a'\")") {
+        REQUIRE_THROWS_WITH(parse(crlf, src),
+                            "expects <CR><LF> but was 'a'");
       }
     }
   }

--- a/test/src/test_either.cpp
+++ b/test/src/test_either.cpp
@@ -22,14 +22,14 @@ SCENARIO("either(p1, p2)", "[cparsec2][parser][either]") {
     }
     WHEN("applied to an input: \"ac\"") {
       Source src = Source_new("ac");
-      THEN("causes an error \"expects 'b' but was 'c'\"") {
-        REQUIRE_THROWS_WITH(parse(p, src), "expects 'b' but was 'c'");
+      THEN("causes an error \"expects \"ab\" but was 'c'\"") {
+        REQUIRE_THROWS_WITH(parse(p, src), "expects \"ab\" but was 'c'");
       }
     }
     WHEN("applied to an input: \"bd\"") {
       Source src = Source_new("bd");
-      THEN("causes an error \"expects 'c' but was 'd'\"") {
-        REQUIRE_THROWS_WITH(parse(p, src), "expects 'c' but was 'd'");
+      THEN("causes an error \"expects \"bc\" but was 'd'\"") {
+        REQUIRE_THROWS_WITH(parse(p, src), "expects \"bc\" but was 'd'");
       }
     }
     WHEN("applied to an input: \"b\"") {
@@ -56,14 +56,14 @@ SCENARIO("either(p1, p2)", "[cparsec2][parser][either]") {
     }
     WHEN("applied to an input: \"ac\"") {
       Source src = Source_new("ac");
-      THEN("causes an error \"expects 'b' but was 'c'\"") {
-        REQUIRE_THROWS_WITH(parse(p, src), "expects 'b' but was 'c'");
+      THEN("causes an error \"expects \"ab\" but was 'c'\"") {
+        REQUIRE_THROWS_WITH(parse(p, src), "expects \"ab\" but was 'c'");
       }
     }
     WHEN("applied to an input: \"bd\"") {
       Source src = Source_new("bd");
-      THEN("causes an error \"expects 'c' but was 'd'\"") {
-        REQUIRE_THROWS_WITH(parse(p, src), "expects 'c' but was 'd'");
+      THEN("causes an error \"expects \"bc\" but was 'd'\"") {
+        REQUIRE_THROWS_WITH(parse(p, src), "expects \"bc\" but was 'd'");
       }
     }
     WHEN("applied to an input: \"b\"") {
@@ -118,8 +118,8 @@ SCENARIO("either(p1, p2)", "[cparsec2][parser][either]") {
     }
     WHEN("applied to an input: \"+123\"") {
       Source src = Source_new("+123");
-      THEN("causes exception(\"expects '+' but was '1'\")") {
-        REQUIRE_THROWS_WITH(parse(p, src), "expects '+' but was '1'");
+      THEN("causes exception(\"expects \"++\" but was '1'\")") {
+        REQUIRE_THROWS_WITH(parse(p, src), "expects \"++\" but was '1'");
       }
     }
   }
@@ -150,8 +150,8 @@ SCENARIO("either(p1, p2)", "[cparsec2][parser][either]") {
     }
     WHEN("applied to an input: \"+123++456++789\"") {
       Source src = Source_new("+123++456++789");
-      THEN("causes exception(\"expects '+' but was '1'\")") {
-        REQUIRE_THROWS_WITH(parse(p, src), "expects '+' but was '1'");
+      THEN("causes exception(\"expects \"++\" but was '1'\")") {
+        REQUIRE_THROWS_WITH(parse(p, src), "expects \"++\" but was '1'");
       }
     }
   }
@@ -182,8 +182,8 @@ SCENARIO("either(p1, p2)", "[cparsec2][parser][either]") {
     }
     WHEN("applied to an input: \"+123++456++789\"") {
       Source src = Source_new("+123++456++789");
-      THEN("causes exception(\"expects '+' but was '1'\")") {
-        REQUIRE_THROWS_WITH(parse(p, src), "expects '+' but was '1'");
+      THEN("causes exception(\"expects \"++\" but was '1'\")") {
+        REQUIRE_THROWS_WITH(parse(p, src), "expects \"++\" but was '1'");
       }
     }
   }

--- a/test/src/test_endOfLine.cpp
+++ b/test/src/test_endOfLine.cpp
@@ -19,7 +19,7 @@ SCENARIO("endOfLine", "[cparsec2][parser][endOfLine]") {
     WHEN("apply endOfLine") {
       THEN("cause exception(\"expects <endOfLine> but was '\\t'\")") {
         REQUIRE_THROWS_WITH(parse(endOfLine, src),
-                            "expects <endOfLine> but was '\t'");
+                            "expects <endOfLine> but was '\\t'");
       }
     }
   }

--- a/test/src/test_many1.cpp
+++ b/test/src/test_many1.cpp
@@ -119,9 +119,9 @@ SCENARIO("many1(p)", "[cparsec2][parser][many1]") {
             parse(many1(skip1st(char1(','), number)), src),
             "not satisfy");
         AND_WHEN("apply string1(\",abc\")") {
-          THEN("cause exception(\"expects ',' but was 'a'\")") {
+          THEN("cause exception(\"expects \",abc\" but was 'a'\")") {
             REQUIRE_THROWS_WITH(parse(string1(",abc"), src),
-                                "expects ',' but was 'a'");
+                                "expects \",abc\" but was 'a'");
           }
         }
       }
@@ -132,9 +132,9 @@ SCENARIO("many1(p)", "[cparsec2][parser][many1]") {
             parse(many1(skip1st(char1(','), many1(digit))), src),
             "not satisfy");
         AND_WHEN("apply string1(\",abc\")") {
-          THEN("cause exception(\"expects ',' but was 'a'\")") {
+          THEN("cause exception(\"expects \",abc\" but was 'a'\")") {
             REQUIRE_THROWS_WITH(parse(string1(",abc"), src),
-                                "expects ',' but was 'a'");
+                                "expects \",abc\" but was 'a'");
           }
         }
       }

--- a/test/src/test_newline.cpp
+++ b/test/src/test_newline.cpp
@@ -8,27 +8,27 @@ SCENARIO("newline", "[cparsec2][parser][newline]") {
   GIVEN("an input: \" \" (i.e. SPC)") {
     Source src = Source_new(" ");
     WHEN("apply newline") {
-      THEN("cause exception(\"expects '\\n' but was ' '\")") {
+      THEN("cause exception(\"expects <LF> but was ' '\")") {
         REQUIRE_THROWS_WITH(parse(newline, src),
-                            "expects '\n' but was ' '");
+                            "expects <LF> but was ' '");
       }
     }
   }
   GIVEN("an input: \"\\t\" (i.e. TAB)") {
     Source src = Source_new("\t");
     WHEN("apply newline") {
-      THEN("cause exception(\"expects '\\n' but was '\\t'\")") {
+      THEN("cause exception(\"expects <LF> but was '\\t'\")") {
         REQUIRE_THROWS_WITH(parse(newline, src),
-                            "expects '\n' but was '\t'");
+                            "expects <LF> but was '\\t'");
       }
     }
   }
   GIVEN("an input: \"\\r\" (i.e. CR)") {
     Source src = Source_new("\r");
     WHEN("apply newline") {
-      THEN("cause exception(\"expects '\\n' but was '\\r'\")") {
+      THEN("cause exception(\"expects <LF> but was '\\r'\")") {
         REQUIRE_THROWS_WITH(parse(newline, src),
-                            "expects '\n' but was '\r'");
+                            "expects <LF> but was '\\r'");
       }
     }
   }
@@ -43,9 +43,9 @@ SCENARIO("newline", "[cparsec2][parser][newline]") {
   GIVEN("an input: \"a\"") {
     Source src = Source_new("a");
     WHEN("apply newline") {
-      THEN("cause exception(\"expects '\\n' but was 'a'\")") {
+      THEN("cause exception(\"expects <LF> but was 'a'\")") {
         REQUIRE_THROWS_WITH(parse(newline, src),
-                            "expects '\n' but was 'a'");
+                            "expects <LF> but was 'a'");
       }
     }
   }

--- a/test/src/test_skip.cpp
+++ b/test/src/test_skip.cpp
@@ -34,9 +34,9 @@ SCENARIO("skip", "[cparsec2][parser][skip]") {
       }
     }
     WHEN("apply skip(string1(\"bc\"))") {
-      THEN("cause exception(\"expects 'b' but was 'a'\")") {
+      THEN("cause exception(\"expects \"bc\" but was 'a'\")") {
         REQUIRE_THROWS_WITH(parse(skip(string1("bc")), src),
-                            "expects 'b' but was 'a'");
+                            "expects \"bc\" but was 'a'");
       }
     }
   }

--- a/test/src/test_skip1st.cpp
+++ b/test/src/test_skip1st.cpp
@@ -21,10 +21,10 @@ SCENARIO("skip1st", "[cparsec2][parser][skip1st]") {
       }
     }
     WHEN("apply skip1st(char1('a'), string1(\"XY\"))") {
-      THEN("cause exception(\"expects 'X' but was 'b'\")") {
+      THEN("cause exception(\"expects \"XY\" but was 'b'\")") {
         REQUIRE_THROWS_WITH(
             parse(skip1st(char1('a'), string1("XY")), src),
-            "expects 'X' but was 'b'");
+            "expects \"XY\" but was 'b'");
       }
     }
     WHEN("apply skip1st(string1(\"ab\"), char1('c'))") {
@@ -33,10 +33,10 @@ SCENARIO("skip1st", "[cparsec2][parser][skip1st]") {
       }
     }
     WHEN("apply skip1st(string1(\"aX\"), char1('c'))") {
-      THEN("cause exception(\"expects 'X' but was 'b'\")") {
+      THEN("cause exception(\"expects \"aX\" but was 'b'\")") {
         REQUIRE_THROWS_WITH(
             parse(skip1st(string1("aX"), char1('c')), src),
-            "expects 'X' but was 'b'");
+            "expects \"aX\" but was 'b'");
       }
     }
     WHEN("apply skip1st(string1(\"ab\"), char1('X'))") {

--- a/test/src/test_skip2nd.cpp
+++ b/test/src/test_skip2nd.cpp
@@ -20,10 +20,10 @@ SCENARIO("skip2nd", "[cparsec2][parser][skip2nd]") {
       }
     }
     WHEN("apply skip2nd(char1('a'), string1(\"XY\"))") {
-      THEN("cause exception(\"expects 'X' but was 'b'\")") {
+      THEN("cause exception(\"expects \"XY\" but was 'b'\")") {
         REQUIRE_THROWS_WITH(
             parse(skip2nd(char1('a'), string1("XY")), src),
-            "expects 'X' but was 'b'");
+            "expects \"XY\" but was 'b'");
       }
     }
     WHEN("apply skip2nd(string1(\"ab\"), char1('c'))") {
@@ -33,10 +33,10 @@ SCENARIO("skip2nd", "[cparsec2][parser][skip2nd]") {
       }
     }
     WHEN("apply skip2nd(string1(\"aX\"), char1('c'))") {
-      THEN("cause exception(\"expects 'X' but was 'b'\")") {
+      THEN("cause exception(\"expects \"aX\" but was 'b'\")") {
         REQUIRE_THROWS_WITH(
             parse(skip2nd(string1("aX"), char1('c')), src),
-            "expects 'X' but was 'b'");
+            "expects \"aX\" but was 'b'");
       }
     }
     WHEN("apply skip2nd(string1(\"ab\"), char1('X'))") {

--- a/test/src/test_string1.cpp
+++ b/test/src/test_string1.cpp
@@ -32,9 +32,9 @@ SCENARIO("string1(str)", "[cparsec2][parser][string1]") {
   GIVEN("an input: \"a123bc\"") {
     Source src = Source_new("a123bc");
     WHEN("apply string1(\"a1234\")") {
-      THEN("cause exception(\"expects '4' but was 'b'\")") {
+      THEN("cause exception(\"expects \"a1234\" but was 'b'\")") {
         REQUIRE_THROWS_WITH(parse(string1("a1234"), src),
-                            "expects '4' but was 'b'");
+                            "expects \"a1234\" but was 'b'");
       }
     }
   }

--- a/test/src/test_tab.cpp
+++ b/test/src/test_tab.cpp
@@ -8,8 +8,8 @@ SCENARIO("tab", "[cparsec2][parser][tab]") {
   GIVEN("an input: \" \" (i.e. SPC)") {
     Source src = Source_new(" ");
     WHEN("apply tab") {
-      THEN("cause exception(\"expects '\\t' but was ' '\")") {
-        REQUIRE_THROWS_WITH(parse(tab, src), "expects '\t' but was ' '");
+      THEN("cause exception(\"expects a TAB but was ' '\")") {
+        REQUIRE_THROWS_WITH(parse(tab, src), "expects a TAB but was ' '");
       }
     }
   }
@@ -24,24 +24,24 @@ SCENARIO("tab", "[cparsec2][parser][tab]") {
   GIVEN("an input: \"\\r\" (i.e. CR)") {
     Source src = Source_new("\r");
     WHEN("apply tab") {
-      THEN("cause exception(\"expects '\\t' but was '\\r'\")") {
-        REQUIRE_THROWS_WITH(parse(tab, src), "expects '\t' but was '\r'");
+      THEN("cause exception(\"expects a TAB but was '\\r'\")") {
+        REQUIRE_THROWS_WITH(parse(tab, src), "expects a TAB but was '\\r'");
       }
     }
   }
   GIVEN("an input: \"\\n\" (i.e. LF)") {
     Source src = Source_new("\n");
     WHEN("apply tab") {
-      THEN("cause exception(\"expects '\\t' but was '\\n'\")") {
-        REQUIRE_THROWS_WITH(parse(tab, src), "expects '\t' but was '\n'");
+      THEN("cause exception(\"expects a TAB but was '\\n'\")") {
+        REQUIRE_THROWS_WITH(parse(tab, src), "expects a TAB but was '\\n'");
       }
     }
   }
   GIVEN("an input: \"a\"") {
     Source src = Source_new("a");
     WHEN("apply tab") {
-      THEN("cause exception(\"expects '\\t' but was 'a'\")") {
-        REQUIRE_THROWS_WITH(parse(tab, src), "expects '\t' but was 'a'");
+      THEN("cause exception(\"expects a TAB but was 'a'\")") {
+        REQUIRE_THROWS_WITH(parse(tab, src), "expects a TAB but was 'a'");
       }
     }
   }

--- a/test/src/test_token.cpp
+++ b/test/src/test_token.cpp
@@ -91,9 +91,9 @@ SCENARIO("token(\"foo\")", "[cparsec2][parser][token]") {
               THEN("results \"foo\"") {
                 REQUIRE(std::string("foo") == parse(foo, src));
                 AND_WHEN("apply foo") {
-                  THEN("cause exception(\"expects 'f' but was 'b'\")") {
+                  THEN("cause exception(\"expects \"foo\" but was 'b'\")") {
                     REQUIRE_THROWS_WITH(parse(foo, src),
-                                        "expects 'f' but was 'b'");
+                                        "expects \"foo\" but was 'b'");
                   }
                 }
               }

--- a/test/src/test_tryp.cpp
+++ b/test/src/test_tryp.cpp
@@ -42,15 +42,15 @@ SCENARIO("tryp(p)", "[cparsec2][parser][tryp]") {
     WHEN("an input was \"ac\"") {
       Source src = Source_new("ac");
       THEN("applied 'p' causes an exception "
-           "\"expects 'b' but was 'a'\"") {
-        REQUIRE_THROWS_WITH(parse(p, src), "expects 'b' but was 'a'");
+           "\"expects \"bc\" but was 'a'\"") {
+        REQUIRE_THROWS_WITH(parse(p, src), "expects \"bc\" but was 'a'");
       }
     }
     WHEN("an input was \"bd\"") {
       Source src = Source_new("bd");
       THEN("applied 'p' causes an exception "
-           "\"expects 'c' but was 'd'\"") {
-        REQUIRE_THROWS_WITH(parse(p, src), "expects 'c' but was 'd'");
+           "\"expects \"bc\" but was 'd'\"") {
+        REQUIRE_THROWS_WITH(parse(p, src), "expects \"bc\" but was 'd'");
       }
     }
     WHEN("an input was \"b\"") {


### PR DESCRIPTION
For enhancement of error messages:
- added `ParseError`
- added `ErrMsg`
- added `void parseError(Source src, ErrMsg msg)`
- added `ParseError getParseError(Source src)`
- added `void setParseError(Source src, ParseError err)`
- added `const char* getParseErrorAsString(Source src)`
- revised `expects` combinator as a generic combinator
- applied `expects` combinator for all built-in parsers
