### PR TITLE
fixed `many(p)`: applied to a parser `p` that accepts an empty input

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -189,5 +189,15 @@ static void self_tests(void) {
                     ",123,456,789"));
   /* -> ["123", "456", "789"] */
 
+  assert(!PARSE_TEST(many(endOfFile), ""));       /* error */
+  assert(!PARSE_TEST(many(spaces), "aaa"));       /* error */
+  assert(!PARSE_TEST(many(skip(endOfFile)), "")); /* error */
+  assert(!PARSE_TEST(many(skip(spaces)), "aaa")); /* error */
+
+  assert(!PARSE_TEST(many1(endOfFile), ""));       /* error */
+  assert(!PARSE_TEST(many1(spaces), "aaa"));       /* error */
+  assert(!PARSE_TEST(many1(skip(endOfFile)), "")); /* error */
+  assert(!PARSE_TEST(many1(skip(spaces)), "aaa")); /* error */
+
   cparsec2_end();
 }

--- a/src/many.c
+++ b/src/many.c
@@ -14,6 +14,10 @@
       for (;;) {                                                         \
         offset = getSourceOffset(src);                                   \
         buff_push(&str, parse(parser, src, &ctx));                       \
+        if (offset == getSourceOffset(src)) {                            \
+          cthrow(ex, error("combinator 'many' is applied to a parser "   \
+                           "that accepts an empty input."));             \
+        }                                                                \
       }                                                                  \
     }                                                                    \
     if (offset != getSourceOffset(src)) {                                \


### PR DESCRIPTION
if `p` was a parser that success without consuming any input,
a parser created by `many(p)` must fail for avoiding infinite loop.

e.g. `PARSE_TEST(many(endOfFile), "")` must fail.