### PR TITLE
fixed #82 "runParser(p, input) returns broken result on MINGW"

### DIFF
--- a/.project.mk
+++ b/.project.mk
@@ -2,7 +2,7 @@
 TARGET    = bin/cparsec2
 LIBTARGET = lib/libcparsec2.a
 
-CFLAGS   += -D_POSIX_C_SOURCE=200809L -D_FILE_OFFSET_BITS=64
+CFLAGS   += -D_POSIX_C_SOURCE=200809L
 CFLAGS   += -std=c11 -I include
 LDFLAGS  +=
 LDLIBS   +=

--- a/include/cparsec2/parseerror.h
+++ b/include/cparsec2/parseerror.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "sourcepos.h"
 
@@ -32,7 +33,7 @@ TYPEDEF_BUFF(ErrMsg, ErrMsg);
 DECLARE_BUFF(ErrMsg);
 
 typedef struct {
-  off_t offset;
+  intmax_t offset;
   SourcePos pos;
   List(ErrMsg) msgs;
 } ParseError;
@@ -40,9 +41,9 @@ typedef struct {
 /** Constructs a ParseError without message */
 ParseError ParseError_new(void);
 /** Gets the source-offset of the ParseError `e` */
-off_t ParseError_getOffset(ParseError e);
+intmax_t ParseError_getOffset(ParseError e);
 /** Sets the source-offset to the ParseError `e` */
-ParseError ParseError_setOffset(off_t offset, ParseError e);
+ParseError ParseError_setOffset(intmax_t offset, ParseError e);
 /** Gets the source-position of the ParseError `e` */
 SourcePos ParseError_getPos(ParseError e);
 /** Sets the source-position to the ParseError `e` */

--- a/include/cparsec2/source.h
+++ b/include/cparsec2/source.h
@@ -1,6 +1,7 @@
 /* -*- coding:utf-8-unix -*- */
 #pragma once
 
+#include <stdint.h>
 #include <stdio.h>
 #include <sys/types.h>
 
@@ -21,9 +22,11 @@ typedef struct stSource* Source;
            , char*       : newStringSource                               \
            , const char* : newStringSource                               \
            , FILE*       : newFileSource                                 \
+           , Source      : Source_identity                               \
            )(x)
 // clang-format on
 
+Source Source_identity(Source src);
 // Construct new Source object from a string.
 Source newStringSource(const char* text);
 // Construct new Source object from a FILE pointer.
@@ -33,9 +36,9 @@ char peek(Source src, Ctx* ctx);
 // drop head char
 void consume(Source src);
 // get current source offset (backup state of the source)
-off_t getSourceOffset(Source src);
+intmax_t getSourceOffset(Source src);
 // set current souce offset (revert state of the source)
-void setSourceOffset(Source src, off_t offset);
+void setSourceOffset(Source src, intmax_t offset);
 // get current source position (backup state of the source)
 SourcePos getSourcePos(Source src);
 // set current souce position (revert state of the source)

--- a/include/cparsec2/stream.h
+++ b/include/cparsec2/stream.h
@@ -1,6 +1,7 @@
 /* -*- coding:utf-8-unix -*- */
 #pragma once
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -29,8 +30,8 @@ Stream Stream_new_mem(const char* s);
 Stream Stream_new_fp(FILE* fp);
 
 size_t Stream_read(void* ptr, size_t size, Stream s, Ctx* ex);
-off_t Stream_getpos(Stream s, Ctx* ex);
-void Stream_setpos(off_t pos, Stream s, Ctx* ex);
+intmax_t Stream_getpos(Stream s, Ctx* ex);
+void Stream_setpos(intmax_t pos, Stream s, Ctx* ex);
 
 #ifdef __cplusplus
 }

--- a/include/cparsec2/tgparse.h
+++ b/include/cparsec2/tgparse.h
@@ -27,15 +27,13 @@
 // template<class T, class S>
 // ParseResult<T> runParser(Parser<T> p, S input);
 #define runParser(p, input)                                              \
-  runParserEx(p, Source_CAST(input), !isSource(input))
+  runParserEx(p, Source_new(input), !isSource(input))
 
 // template<class T>
 // ParseResult<T> runParserEx(Parser<T> p, Source src, bool del);
 #define runParserEx(p, src, del)                                         \
-  GENERIC_P(PARSER_CAST(p), RUNPARSER_EX, TYPESET(1))                    \
-  (PARSER_CAST(p), (src), (del))
+  (GENERIC_P(PARSER_CAST(p), RUNPARSER_EX, TYPESET(1)))(PARSER_CAST(p),  \
+                                                        (src), (del))
 
-#define isSource(input) _Generic((input), Source : true, default : false)
-
-#define Source_CAST(input)                                               \
-  _Generic((input), Source : (input), default : Source_new(input))
+#define isSource(input)                                                  \
+  (_Generic((input), Source : true, default : false))

--- a/src/char1.c
+++ b/src/char1.c
@@ -56,7 +56,8 @@ static char run_char1(void* arg, Source src, Ctx* ex) {
     consume(src);
     return c;
   }
-  parseError(src, (ErrMsg){SysUnexpect, c2s(c)});
+  ErrMsg m = {SysUnexpect, c2s(c)};
+  parseError(src, m);
   cthrow(ex, error("expects %s but was %s", c2s(expected), c2s(c)));
 }
 

--- a/src/either.c
+++ b/src/either.c
@@ -7,7 +7,7 @@
   static RETURN_TYPE(PARSER(T))                                          \
       EITHER_FN(T)(void* arg, Source src, Ctx* ex) {                     \
     PARSER(T)* p = (PARSER(T)*)arg;                                      \
-    off_t pos = getSourceOffset(src);                                    \
+    intmax_t pos = getSourceOffset(src);                                 \
     Ctx ctx;                                                             \
     TRY(&ctx) {                                                          \
       return parse(p[0], src, &ctx);                                     \

--- a/src/exception.c
+++ b/src/exception.c
@@ -6,5 +6,5 @@
 
 _Noreturn void cthrow(Ctx* ctx, const char* msg) {
   ctx->msg = msg;
-  longjmp(ctx->e, -1);
+  longjmp(ctx->e, 1);
 }

--- a/src/expects.c
+++ b/src/expects.c
@@ -11,7 +11,7 @@
     void** ps = (void**)arg;                                             \
     const char* desc = ps[0];                                            \
     PARSER(T) p = ps[1];                                                 \
-    off_t pos = getSourceOffset(src);                                    \
+    intmax_t pos = getSourceOffset(src);                                 \
     Ctx ctx;                                                             \
     TRY(&ctx) {                                                          \
       return parse(p, src, &ctx);                                        \

--- a/src/many.c
+++ b/src/many.c
@@ -8,7 +8,7 @@
     UNUSED(ex);                                                          \
     PARSER(T) parser = (PARSER(T))arg;                                   \
     Buff(T) str = {0};                                                   \
-    off_t offset;                                                        \
+    volatile intmax_t offset;                                            \
     Ctx ctx;                                                             \
     TRY(&ctx) {                                                          \
       for (;;) {                                                         \

--- a/src/parseerror.c
+++ b/src/parseerror.c
@@ -11,11 +11,11 @@ DEFINE_LIST(ErrMsg);
 DEFINE_BUFF(ErrMsg);
 
 /** Gets the source-offset of the ParseError `e` */
-off_t ParseError_getOffset(ParseError e) {
+intmax_t ParseError_getOffset(ParseError e) {
   return e.offset;
 }
 /** Sets the source-offset to the ParseError `e` */
-ParseError ParseError_setOffset(off_t offset, ParseError e) {
+ParseError ParseError_setOffset(intmax_t offset, ParseError e) {
   e.offset = offset;
   return e;
 }

--- a/src/seq.c
+++ b/src/seq.c
@@ -5,10 +5,10 @@
 #define SEQ_FN(T) CAT(run_seq, T)
 #define DEFINE_SEQ(T)                                                    \
   static List(T) SEQ_FN(T)(void* arg, Source src, Ctx* ex) {             \
-    PARSER(T)* p = (PARSER(T)*)arg;                                      \
     Buff(T) str = {0};                                                   \
     Ctx ctx;                                                             \
     TRY(&ctx) {                                                          \
+      PARSER(T)* p = (PARSER(T)*)arg;                                   \
       while (*p) {                                                       \
         buff_push(&str, parse(*p, src, &ctx));                           \
         p++;                                                             \

--- a/src/stream.c
+++ b/src/stream.c
@@ -56,23 +56,23 @@ size_t Stream_read(void* ptr, size_t size, Stream s, Ctx* ex) {
   }
 }
 
-off_t Stream_getpos(Stream s, Ctx* ex) {
+intmax_t Stream_getpos(Stream s, Ctx* ex) {
   if (s->fp) {
     off_t pos = ftello(s->fp);
     if (pos == -1) {
       cthrow(ex, mem_printf("%s", strerror(errno)));
     }
-    return pos;
+    return (intmax_t)pos;
   }
   else {
     assert(s->beg <= s->p && s->p <= s->end);
-    return (off_t)(s->p - s->beg);
+    return (intmax_t)(s->p - s->beg);
   }
 }
 
-void Stream_setpos(off_t pos, Stream s, Ctx* ex) {
+void Stream_setpos(intmax_t pos, Stream s, Ctx* ex) {
   if (s->fp) {
-    if (fseeko(s->fp, pos, SEEK_SET) == -1) {
+    if (fseeko(s->fp, (off_t)pos, SEEK_SET) == -1) {
       cthrow(ex, mem_printf("%s", strerror(errno)));
     }
   }

--- a/src/string1.c
+++ b/src/string1.c
@@ -28,7 +28,8 @@ static const char* run_string1(void* arg, Source src, Ctx* ex) {
     // exact match
     return actual;
   }
-  parseError(src, (ErrMsg){SysUnexpect, to_s(actual)});
+  ErrMsg m = {SysUnexpect, to_s(actual)};
+  parseError(src, m);
   mem_free((void*)actual);
   cthrow(ex, error("unexpected tokens"));
 }

--- a/src/tryp.c
+++ b/src/tryp.c
@@ -7,7 +7,7 @@
   static RETURN_TYPE(PARSER(T))                                          \
       TRYP_FN(T)(void* arg, Source src, Ctx* ex) {                       \
     PARSER(T) p = (PARSER(T))arg;                                        \
-    off_t offset = getSourceOffset(src);                                 \
+    intmax_t offset = getSourceOffset(src);                              \
     SourcePos pos = getSourcePos(src);                                   \
     Ctx ctx;                                                             \
     TRY(&ctx) {                                                          \

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -11,7 +11,7 @@ PARSER(String) utf8(const char* s) {
     }
   }
   else {
-    off_t pos = getSourceOffset(src);
+    intmax_t pos = getSourceOffset(src);
     assert(pos == list_length(s));
     mem_free((void*)ctx.msg);
   }


### PR DESCRIPTION
- Replaced `off_t` with `intmax_t` for all APIs.
- Removed `-D_FILE_OFFSET_BITS=64` from `project.mk`
- and some minor fixes.