### PR TITLE
added TestIt-comparators (eq, ne, lt, le, gt, ge)

### DIFF
--- a/testit/include/testit.h
+++ b/testit/include/testit.h
@@ -1,12 +1,18 @@
 // -*- coding: utf-8-unix -*-
 #pragma once
 
+#include <stdint.h>
+#include <string.h>
 #include <unistd.h>
 
 #ifdef __cplusplus
-#define TESTIT_EXTERN extern "C"
+#define TESTIT_CAPI extern "C"
+#define TESTIT_BEGIN_CAPI extern "C" {
+#define TESTIT_END_CAPI }
 #else
-#define TESTIT_EXTERN
+#define TESTIT_CAPI
+#define TESTIT_BEGIN_CAPI
+#define TESTIT_END_CAPI
 #endif
 
 #if !defined(TestSuite)
@@ -22,16 +28,27 @@
 #define TESTIT_ANONYMOUS_ID() TESTIT_CAT(anonymous, __LINE__)
 #endif
 
+// ----
+
 #define test(...) testit(TestSuite, TESTIT_ANONYMOUS_ID(), __VA_ARGS__)
 #define testit(suite, name, ...) TESTIT0(suite, name, __VA_ARGS__)
 
-#define c_assert(expr) TESTIT_assert(expr)
+#define c_assert(expr) TESTIT_assert(#expr, expr)
 #define c_abort(msg) TESTIT_abort(__LINE__, msg)
+
+#define eq(a, b) TESTIT_BINARY_OPERATOR(testit_eq, a, b)
+#define le(a, b) TESTIT_BINARY_OPERATOR(testit_le, a, b)
+#define lt(a, b) TESTIT_BINARY_OPERATOR(testit_lt, a, b)
+#define ne(a, b) !eq(a, b)
+#define ge(a, b) !lt(a, b)
+#define gt(a, b) !le(a, b)
+
+// ----
 
 #define TESTIT0(suite_, name_, ...) TESTIT1(suite_, name_, __VA_ARGS__)
 #define TESTIT1(suite_, name_, ...)                                      \
   static void TESTIT_FUNC(suite_, name_)(void);                          \
-  TESTIT_EXTERN TestSt TESTIT_TEST(suite_, name_) = {                    \
+  TESTIT_CAPI TestSt TESTIT_TEST(suite_, name_) = {                      \
       .file = __FILE__,                                                  \
       .line = __LINE__,                                                  \
       .suite = #suite_,                                                  \
@@ -45,10 +62,10 @@
 #define TESTIT_TEST(suite, id) TESTIT_IDENT(TestIt_test__, suite, id)
 #define TESTIT_FUNC(suite, id) TESTIT_IDENT(TestIt_run__, suite, id)
 
-#define TESTIT_assert(expr)                                              \
+#define TESTIT_assert(exprstr, expr)                                     \
   do {                                                                   \
     if (!(expr)) {                                                       \
-      c_abort("Assertion failed `" #expr "'");                           \
+      c_abort("Assertion failed `" exprstr "'");                         \
     }                                                                    \
   } while (0)
 
@@ -56,9 +73,26 @@
 #define TESTIT_abort_0(line, msg)                                        \
   TestIt_abort("" __FILE__ ":" #line ": " msg)
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+// ----
+
+#define TESTIT_BINARY_OPERATOR(op, a, b)                                 \
+  _Generic((a)                                                           \
+           , int8_t   : op##_I8                                          \
+           , int16_t  : op##_I16                                         \
+           , int32_t  : op##_I32                                         \
+           , int64_t  : op##_I64                                         \
+           , uint8_t  : op##_U8                                          \
+           , uint16_t : op##_U16                                         \
+           , uint32_t : op##_U32                                         \
+           , uint64_t : op##_U64                                         \
+           , char     : op##_Char                                        \
+           , void*    : op##_Ptr                                         \
+           , char*    : op##_String                                      \
+           )((a), (b))
+
+// ----
+
+TESTIT_BEGIN_CAPI
 
 #include <stdbool.h>
 
@@ -79,17 +113,116 @@ typedef struct TestSt {
 void TestIt_abort(const char* msg);
 void* testit_current_test_data(void);
 
-#ifdef __cplusplus
+static inline bool testit_eq_I8(int8_t a, int8_t b) {
+  return a == b;
 }
-#endif
+static inline bool testit_eq_I16(int16_t a, int16_t b) {
+  return a == b;
+}
+static inline bool testit_eq_I32(int32_t a, int32_t b) {
+  return a == b;
+}
+static inline bool testit_eq_I64(int64_t a, int64_t b) {
+  return a == b;
+}
+static inline bool testit_eq_U8(uint8_t a, uint8_t b) {
+  return a == b;
+}
+static inline bool testit_eq_U16(uint16_t a, uint16_t b) {
+  return a == b;
+}
+static inline bool testit_eq_U32(uint32_t a, uint32_t b) {
+  return a == b;
+}
+static inline bool testit_eq_U64(uint64_t a, uint64_t b) {
+  return a == b;
+}
+static inline bool testit_eq_Char(char a, char b) {
+  return a == b;
+}
+static inline bool testit_eq_Ptr(void* a, void* b) {
+  return a == b;
+}
+static inline bool testit_eq_String(const char* a, const char* b) {
+  return !strcmp(a, b);
+}
+
+static inline bool testit_lt_I8(int8_t a, int8_t b) {
+  return a < b;
+}
+static inline bool testit_lt_I16(int16_t a, int16_t b) {
+  return a < b;
+}
+static inline bool testit_lt_I32(int32_t a, int32_t b) {
+  return a < b;
+}
+static inline bool testit_lt_I64(int64_t a, int64_t b) {
+  return a < b;
+}
+static inline bool testit_lt_U8(uint8_t a, uint8_t b) {
+  return a < b;
+}
+static inline bool testit_lt_U16(uint16_t a, uint16_t b) {
+  return a < b;
+}
+static inline bool testit_lt_U32(uint32_t a, uint32_t b) {
+  return a < b;
+}
+static inline bool testit_lt_U64(uint64_t a, uint64_t b) {
+  return a < b;
+}
+static inline bool testit_lt_Char(char a, char b) {
+  return a < b;
+}
+static inline bool testit_lt_Ptr(void* a, void* b) {
+  return a < b;
+}
+static inline bool testit_lt_String(const char* a, const char* b) {
+  return strcmp(a, b) < 0;
+}
+
+static inline bool testit_le_I8(int8_t a, int8_t b) {
+  return a <= b;
+}
+static inline bool testit_le_I16(int16_t a, int16_t b) {
+  return a <= b;
+}
+static inline bool testit_le_I32(int32_t a, int32_t b) {
+  return a <= b;
+}
+static inline bool testit_le_I64(int64_t a, int64_t b) {
+  return a <= b;
+}
+static inline bool testit_le_U8(uint8_t a, uint8_t b) {
+  return a <= b;
+}
+static inline bool testit_le_U16(uint16_t a, uint16_t b) {
+  return a <= b;
+}
+static inline bool testit_le_U32(uint32_t a, uint32_t b) {
+  return a <= b;
+}
+static inline bool testit_le_U64(uint64_t a, uint64_t b) {
+  return a <= b;
+}
+static inline bool testit_le_Char(char a, char b) {
+  return a <= b;
+}
+static inline bool testit_le_Ptr(void* a, void* b) {
+  return a <= b;
+}
+static inline bool testit_le_String(const char* a, const char* b) {
+  return strcmp(a, b) <= 0;
+}
+
+TESTIT_END_CAPI
 
 // ---- main ----
 #ifdef TESTIT_CONFIG_MAIN
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <setjmp.h>
 #include <stdio.h>
+
+TESTIT_BEGIN_CAPI
 
 extern Test* testit_tests_;
 extern int testit_tests_total_;
@@ -316,8 +449,6 @@ int main(int argc, char** argv) {
   return runTestRunner();
 }
 
-#ifdef __cplusplus
-}
-#endif
+TESTIT_END_CAPI
 
 #endif

--- a/testit/src/TestIt/test3.c
+++ b/testit/src/TestIt/test3.c
@@ -4,7 +4,6 @@
 
 #define TestSuite parametric
 #include "testit.h"
-#include <cparsec2.h>
 
 static int mul(int x, int y) {
   return x * y;
@@ -43,7 +42,7 @@ static void* dataset1(size_t i) {
 test("mul(x,y) with dataset1", .generator = dataset1) {
   // get the current value provided by generator function.
   struct data* x = testit_current_test_data();
-  c_assert(mul(x->lhs, x->rhs) == x->expect);
+  c_assert(eq(x->expect, mul(x->lhs, x->rhs)));
 }
 
 // if no .generator was given, testit_current_test_data() API fails

--- a/testit/src/TestIt/test_eq.c
+++ b/testit/src/TestIt/test_eq.c
@@ -1,0 +1,313 @@
+/* -*- coding: utf-8-unix -*- */
+
+#define TestSuite testit_eq
+#include "testit.h"
+
+// -- bool --
+
+test("c_assert(eq(false, false)) should pass") {
+  c_assert(eq(false, false));
+}
+
+test("c_assert(eq(false, true)) should fail", .should_fail = true) {
+  c_assert(eq(false, true));
+}
+
+test("c_assert(eq(true, false)) should fail", .should_fail = true) {
+  c_assert(eq(true, false));
+}
+
+test("c_assert(eq(true, true)) should pass") {
+  c_assert(eq(true, true));
+}
+
+// -- char --
+
+test("c_assert(eq('a', 'a')) should pass") {
+  c_assert(eq('a', 'a'));
+}
+
+test("c_assert(eq('a', 'b')) should fail", .should_fail = true) {
+  c_assert(eq('a', 'b'));
+}
+
+test("c_assert(eq('b', 'a')) should fail", .should_fail = true) {
+  c_assert(eq('b', 'a'));
+}
+
+test("c_assert(eq('b', 'b')) should pass") {
+  c_assert(eq('b', 'b'));
+}
+
+// -- integer --
+
+test("c_assert(eq(0, 0)) should pass") {
+  c_assert(eq(0, 0));
+}
+
+test("c_assert(eq(0, 1)) should fail", .should_fail = true) {
+  c_assert(eq(0, 1));
+}
+
+test("c_assert(eq(1, 0)) should fail", .should_fail = true) {
+  c_assert(eq(1, 0));
+}
+
+test("c_assert(eq(1, 1)) should pass") {
+  c_assert(eq(1, 1));
+}
+
+test("c_assert(eq(-1, -1)) should pass") {
+  c_assert(eq(-1, -1));
+}
+
+test("c_assert(eq(-1, 1)) should fail", .should_fail = true) {
+  c_assert(eq(-1, 1));
+}
+
+test("c_assert(eq(1, -1)) should fail", .should_fail = true) {
+  c_assert(eq(1, -1));
+}
+
+// -- string --
+
+test("c_assert(eq(\"abc\", \"abc\")) should pass") {
+  c_assert(eq("abc", "abc"));
+}
+
+test("c_assert(eq(\"abc\", \"ab\")) should fail", .should_fail = true) {
+  c_assert(eq("abc", "ab"));
+}
+
+test("c_assert(eq(\"ab\", \"abc\")) should fail", .should_fail = true) {
+  c_assert(eq("ab", "abc"));
+}
+
+test("c_assert(eq(\"abc\", \"ABC\")) should fail", .should_fail = true) {
+  c_assert(eq("abc", "ABC"));
+}
+
+test("c_assert(eq(\"ABC\", \"abc\")) should fail", .should_fail = true) {
+  c_assert(eq("ABC", "abc"));
+}
+
+test("c_assert(eq(\"ABC\", \"ABC\")) should pass") {
+  c_assert(eq("ABC", "ABC"));
+}
+
+// -- int8_t --
+
+test("c_assert(eq((int8_t)0, (int8_t)0)) should pass") {
+  c_assert(eq((int8_t)0, (int8_t)0));
+}
+
+test("c_assert(eq(INT8_MIN, (int8_t)0)) should fail",
+     .should_fail = true) {
+  c_assert(eq(INT8_MIN, (int8_t)0));
+}
+
+test("c_assert(eq((int8_t)0, INT8_MIN)) should fail",
+     .should_fail = true) {
+  c_assert(eq((int8_t)0, INT8_MIN));
+}
+
+test("c_assert(eq(INT8_MIN, INT8_MIN)) should pass") {
+  c_assert(eq(INT8_MIN, INT8_MIN));
+}
+
+test("c_assert(eq(INT8_MAX, (int8_t)0)) should fail",
+     .should_fail = true) {
+  c_assert(eq(INT8_MAX, (int8_t)0));
+}
+
+test("c_assert(eq((int8_t)0, INT8_MAX)) should fail",
+     .should_fail = true) {
+  c_assert(eq((int8_t)0, INT8_MAX));
+}
+
+test("c_assert(eq(INT8_MAX, INT8_MAX)) should pass") {
+  c_assert(eq(INT8_MAX, INT8_MAX));
+}
+
+// -- uint8_t --
+
+test("c_assert(eq((uint8_t)0, (uint8_t)0)) should pass") {
+  c_assert(eq((uint8_t)0, (uint8_t)0));
+}
+
+test("c_assert(eq(UINT8_MAX, (uint8_t)0)) should fail",
+     .should_fail = true) {
+  c_assert(eq(UINT8_MAX, (uint8_t)0));
+}
+
+test("c_assert(eq((uint8_t)0, UINT8_MAX)) should fail",
+     .should_fail = true) {
+  c_assert(eq((uint8_t)0, UINT8_MAX));
+}
+
+test("c_assert(eq(UINT8_MAX, UINT8_MAX)) should pass") {
+  c_assert(eq(UINT8_MAX, UINT8_MAX));
+}
+
+// -- int16_t --
+
+test("c_assert(eq((int16_t)0, (int16_t)0)) should pass") {
+  c_assert(eq((int16_t)0, (int16_t)0));
+}
+
+test("c_assert(eq(INT16_MIN, (int16_t)0)) should fail",
+     .should_fail = true) {
+  c_assert(eq(INT16_MIN, (int16_t)0));
+}
+
+test("c_assert(eq((int16_t)0, INT16_MIN)) should fail",
+     .should_fail = true) {
+  c_assert(eq((int16_t)0, INT16_MIN));
+}
+
+test("c_assert(eq(INT16_MIN, INT16_MIN)) should pass") {
+  c_assert(eq(INT16_MIN, INT16_MIN));
+}
+
+test("c_assert(eq(INT16_MAX, (int16_t)0)) should fail",
+     .should_fail = true) {
+  c_assert(eq(INT16_MAX, (int16_t)0));
+}
+
+test("c_assert(eq((int16_t)0, INT16_MAX)) should fail",
+     .should_fail = true) {
+  c_assert(eq((int16_t)0, INT16_MAX));
+}
+
+test("c_assert(eq(INT16_MAX, INT16_MAX)) should pass") {
+  c_assert(eq(INT16_MAX, INT16_MAX));
+}
+
+// -- uint16_t --
+
+test("c_assert(eq((uint16_t)0, (uint16_t)0)) should pass") {
+  c_assert(eq((uint16_t)0, (uint16_t)0));
+}
+
+test("c_assert(eq(UINT16_MAX, (uint16_t)0)) should fail",
+     .should_fail = true) {
+  c_assert(eq(UINT16_MAX, (uint16_t)0));
+}
+
+test("c_assert(eq((uint16_t)0, UINT16_MAX)) should fail",
+     .should_fail = true) {
+  c_assert(eq((uint16_t)0, UINT16_MAX));
+}
+
+test("c_assert(eq(UINT16_MAX, UINT16_MAX)) should pass") {
+  c_assert(eq(UINT16_MAX, UINT16_MAX));
+}
+
+// -- int32_t --
+
+test("c_assert(eq((int32_t)0, (int32_t)0)) should pass") {
+  c_assert(eq((int32_t)0, (int32_t)0));
+}
+
+test("c_assert(eq(INT32_MIN, (int32_t)0)) should fail",
+     .should_fail = true) {
+  c_assert(eq(INT32_MIN, (int32_t)0));
+}
+
+test("c_assert(eq((int32_t)0, INT32_MIN)) should fail",
+     .should_fail = true) {
+  c_assert(eq((int32_t)0, INT32_MIN));
+}
+
+test("c_assert(eq(INT32_MIN, INT32_MIN)) should pass") {
+  c_assert(eq(INT32_MIN, INT32_MIN));
+}
+
+test("c_assert(eq(INT32_MAX, (int32_t)0)) should fail",
+     .should_fail = true) {
+  c_assert(eq(INT32_MAX, (int32_t)0));
+}
+
+test("c_assert(eq((int32_t)0, INT32_MAX)) should fail",
+     .should_fail = true) {
+  c_assert(eq((int32_t)0, INT32_MAX));
+}
+
+test("c_assert(eq(INT32_MAX, INT32_MAX)) should pass") {
+  c_assert(eq(INT32_MAX, INT32_MAX));
+}
+
+// -- uint32_t --
+
+test("c_assert(eq((uint32_t)0, (uint32_t)0)) should pass") {
+  c_assert(eq((uint32_t)0, (uint32_t)0));
+}
+
+test("c_assert(eq(UINT32_MAX, (uint32_t)0)) should fail",
+     .should_fail = true) {
+  c_assert(eq(UINT32_MAX, (uint32_t)0));
+}
+
+test("c_assert(eq((uint32_t)0, UINT32_MAX)) should fail",
+     .should_fail = true) {
+  c_assert(eq((uint32_t)0, UINT32_MAX));
+}
+
+test("c_assert(eq(UINT32_MAX, UINT32_MAX)) should pass") {
+  c_assert(eq(UINT32_MAX, UINT32_MAX));
+}
+
+// -- int64_t --
+
+test("c_assert(eq((int64_t)0, (int64_t)0)) should pass") {
+  c_assert(eq((int64_t)0, (int64_t)0));
+}
+
+test("c_assert(eq(INT64_MIN, (int64_t)0)) should fail",
+     .should_fail = true) {
+  c_assert(eq(INT64_MIN, (int64_t)0));
+}
+
+test("c_assert(eq((int64_t)0, INT64_MIN)) should fail",
+     .should_fail = true) {
+  c_assert(eq((int64_t)0, INT64_MIN));
+}
+
+test("c_assert(eq(INT64_MIN, INT64_MIN)) should pass") {
+  c_assert(eq(INT64_MIN, INT64_MIN));
+}
+
+test("c_assert(eq(INT64_MAX, (int64_t)0)) should fail",
+     .should_fail = true) {
+  c_assert(eq(INT64_MAX, (int64_t)0));
+}
+
+test("c_assert(eq((int64_t)0, INT64_MAX)) should fail",
+     .should_fail = true) {
+  c_assert(eq((int64_t)0, INT64_MAX));
+}
+
+test("c_assert(eq(INT64_MAX, INT64_MAX)) should pass") {
+  c_assert(eq(INT64_MAX, INT64_MAX));
+}
+
+// -- uint64_t --
+
+test("c_assert(eq((uint64_t)0, (uint64_t)0)) should pass") {
+  c_assert(eq((uint64_t)0, (uint64_t)0));
+}
+
+test("c_assert(eq(UINT64_MAX, (uint64_t)0)) should fail",
+     .should_fail = true) {
+  c_assert(eq(UINT64_MAX, (uint64_t)0));
+}
+
+test("c_assert(eq((uint64_t)0, UINT64_MAX)) should fail",
+     .should_fail = true) {
+  c_assert(eq((uint64_t)0, UINT64_MAX));
+}
+
+test("c_assert(eq(UINT64_MAX, UINT64_MAX)) should pass") {
+  c_assert(eq(UINT64_MAX, UINT64_MAX));
+}
+


### PR DESCRIPTION
We can now write more readable test with TestIt testing framework:
- new syntax : `c_assert(eq("abc", "abc"))` 
- old syntax : `c_assert(!strcmp("abc", "abc"))`