### PR TITLE
API changed: DEFINE_PARER(T, RET) -> DEFINE_PARSER(T)

### DIFF
--- a/docs/API.org
+++ b/docs/API.org
@@ -653,9 +653,11 @@ not for users at the present.
 - DECLARE_PARSER(T)     :: 
      Declares functions/methods for ~PARSER(T)~.
 
-- DEFINE_PARSER(T, x) { ~/* print x; */~ } :: 
-     Defines functions/methods for ~PARSER(T)~.\\
-  - *NOTE* : The trailing block ~{...}~ is body of function ~void SHOW(T)(R x)~.
+- DEFINE_PARSER(T)      :: 
+     Defines functions/methods for ~PARSER(T)~.
+
+- void SHOW(T)(R x) { ~/* print x; */~ } ::
+     Defines function ~void SHOW(T)(R x)~.
   - *NOTE* : ~void SHOW(T)(R x)~ is called by ~parseTest(p, text)~ to print ~x~.
   - *NOTE* : ~x~ is the result of parser ~p~ applied to the ~text~.
 
@@ -674,9 +676,10 @@ Example: 'IntParser.c'
   #include "IntParser.h"
 
   /* Defines (implement) functions/methods for PARSER(Int) */
-  DEFINE_PARSER(Int, x) {
-    /* implementation of void SHOW(Int)(int x) */
-    printf("%d\n", x);
+  DEFINE_PARSER(Int);
+  /* and defines void SHOW(Int)(int x) */
+  void SHOW(Int)(int x) {
+    printf("%d", x);
   }
 #+end_src
 

--- a/example/mult/src/IntParser.c
+++ b/example/mult/src/IntParser.c
@@ -1,15 +1,16 @@
 /* -*- coding: utf-8-unix -*- */
 
-_Static_assert(1, "PARSER(Int) is already defined.");
+_Static_assert(1, "PARSER(Int) and SHOW(Int)(int x) are already defined.");
 
 #if 0
 
 #include "IntParser.h"
 
 /* Defines (implement) functions/methods for PARSER(Int) */
-DEFINE_PARSER(Int, x) {
-  /* implementation of void SHOW(Int)(int x) */
-  printf("%d\n", x);
+DEFINE_PARSER(Int);
+/* implementation of void SHOW(Int)(int x) */
+SHOW(Int)(int x) {
+  printf("%d", x);
 }
 
 #endif

--- a/include/cparsec2/parser.h
+++ b/include/cparsec2/parser.h
@@ -42,9 +42,10 @@
   RETURN_TYPE(PARSER(T)) PARSE(T)(PARSER(T) p, Source src, Ctx * ctx);   \
   bool PARSETEST(T)(const char* msg, PARSER(T) p, const char* input);    \
   PARSER(T) PARSER_ID_FN(T)(PARSER(T) p);                                \
-  void SHOW(T)(RETURN_TYPE(PARSER(T)) val)
+  void SHOW(T)(RETURN_TYPE(PARSER(T)) val);                              \
+  END_OF_STATEMENTS
 
-#define DEFINE_PARSER(T, RET)                                            \
+#define DEFINE_PARSER(T)                                                 \
   struct PARSER_ST(T) {                                                  \
     PARSER_FN(T) run;                                                    \
     void* arg;                                                           \
@@ -65,6 +66,7 @@
     Ctx ctx;                                                             \
     TRY(&ctx) {                                                          \
       SHOW(T)(PARSE(T)(p, src, &ctx));                                   \
+      printf("\n");                                                      \
       return true;                                                       \
     }                                                                    \
     else {                                                               \
@@ -77,7 +79,9 @@
   PARSER(T) PARSER_ID_FN(T)(PARSER(T) p) {                               \
     return p;                                                            \
   }                                                                      \
-  void SHOW(T)(RETURN_TYPE(PARSER(T)) RET)
+  /* SHOW(T)(RETURN_TYPE(PARSER(T) x) must be defined explicitly */      \
+  void SHOW(T)(RETURN_TYPE(PARSER(T)) x);                                \
+  END_OF_STATEMENTS
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/container/buff.c
+++ b/src/container/buff.c
@@ -8,20 +8,8 @@
 
 // ---- Buffer (List builder) ----
 
-// Buff(None)
-DEFINE_BUFF(None);
-
-// Buff(String)
-DEFINE_BUFF(String);
-
-// Buff(Int)
-DEFINE_BUFF(Int);
-
 // Buff(Ptr)
 DEFINE_BUFF(Ptr);
-
-// Buff(Node)
-DEFINE_BUFF(Node);
 
 // Buff(Char) ; a special case of Buff(T)
 DEFINE_BUFF_COMMON(Char);
@@ -31,3 +19,6 @@ List(Char) BUFF_FINISH(Char)(Buff(Char) * b) {
   *b = (Buff(Char)){0};
   return xs;
 }
+
+// Define Buff(T) for each remaining T in ELEMENT_TYPESET.
+FOREACH(DEFINE_BUFF, TYPESET_0());

--- a/src/container/list.c
+++ b/src/container/list.c
@@ -8,20 +8,8 @@
 
 // ---- List ----
 
-// List(None)
-DEFINE_LIST(None);
-
-// List(String)
-DEFINE_LIST(String);
-
-// List(Int)
-DEFINE_LIST(Int);
-
 // List(Ptr)
 DEFINE_LIST(Ptr);
-
-// List(Node)
-DEFINE_LIST(Node);
 
 // List(Char) ; a special case of List(T)
 ELEMENT_TYPE(List(Char)) * LIST_BEGIN(Char)(List(Char) xs) {
@@ -38,3 +26,6 @@ int LIST_LENGTH(Char)(List(Char) xs) {
   assert(n < SIZE_MAX);
   return n;
 }
+
+// Define List(T) for each remaining T in ELEMENT_TYPESET.
+FOREACH(DEFINE_LIST, TYPESET_0());

--- a/src/parser.c
+++ b/src/parser.c
@@ -2,88 +2,43 @@
 
 #include <cparsec2/parser.h>
 
-// ---- NoneParser ----
-DEFINE_PARSER(None, x) {
-  (void)(x);
-  printf("()\n");
+#define DEFINE_SHOW_LIST(T)                                              \
+  void SHOW(List(T))(List(T) xs) {                                       \
+    ELEMENT_TYPE(List(T))* itr = LIST_BEGIN(T)(xs);                      \
+    ELEMENT_TYPE(List(T))* end = LIST_END(T)(xs);                        \
+    if (itr == end) {                                                    \
+      printf("[]");                                                      \
+    } else {                                                             \
+      printf("[");                                                       \
+      SHOW(T)(*itr);                                                     \
+      itr++;                                                             \
+      while (itr != end) {                                               \
+        printf(", ");                                                    \
+        SHOW(T)(*itr);                                                   \
+        itr++;                                                           \
+      }                                                                  \
+      printf("]");                                                       \
+    }                                                                    \
+  }                                                                      \
+  END_OF_STATEMENTS
+
+void SHOW(Char)(char x) {
+  printf("'%c'", x);
+}
+void SHOW(String)(const char* x) {
+  printf("\"%s\"", x);
+}
+void SHOW(Int)(int x) {
+  printf("%d", x);
+}
+void SHOW(None)(None x) {
+  UNUSED(x);
+  printf("()");
+}
+void SHOW(Node)(Node x) {
+  printf("<Node:%p>", (void*)x);
 }
 
-// ---- CharParser ----
-DEFINE_PARSER(Char, x) {
-  printf("'%c'\n", x);
-}
+FOREACH(DEFINE_SHOW_LIST, TYPESET_0());
 
-// ---- StringParser ----
-DEFINE_PARSER(String, x) {
-  printf("\"%s\"\n", x);
-}
-
-// ---- IntParser ----
-DEFINE_PARSER(Int, x) {
-  printf("%d\n", x);
-}
-
-// ---- NoneListParser ----
-DEFINE_PARSER(List(None), x) {
-  None* itr = list_begin(x);
-  None* end = list_end(x);
-  if (itr == end) {
-    printf("[]\n");
-  } else {
-    printf("[()"); itr++;
-    while (itr != end) {
-      printf(", ()"); itr++;
-    }
-    printf("]\n");
-  }
-}
-
-// ---- StringListParser ----
-DEFINE_PARSER(List(String), x) {
-  const char** itr = list_begin(x);
-  const char** end = list_end(x);
-  if (itr == end) {
-    printf("[]\n");
-  } else {
-    printf("[\"%s\"", *itr++);
-    while (itr != end) {
-      printf(", \"%s\"", *itr++);
-    }
-    printf("]\n");
-  }
-}
-
-// ---- IntListParser ----
-DEFINE_PARSER(List(Int), x) {
-  int* itr = list_begin(x);
-  int* end = list_end(x);
-  if (itr == end) {
-    printf("[]\n");
-  } else {
-    printf("[%d", *itr++);
-    while (itr != end) {
-      printf(", %d", *itr++);
-    }
-    printf("]\n");
-  }
-}
-
-// ---- NodeParser ----
-DEFINE_PARSER(Node, x) {
-  printf("<Node:%p>\n", (void*)x);
-}
-
-// ---- NodeListParser ----
-DEFINE_PARSER(List(Node), x) {
-  Node* itr = list_begin(x);
-  Node* end = list_end(x);
-  if (itr == end) {
-    printf("[]\n");
-  } else {
-    printf("[<Node:%p>", (void*)*itr++);
-    while (itr != end) {
-      printf(", <Node:%p>", (void*)*itr++);
-    }
-    printf("]\n");
-  }
-}
+FOREACH(DEFINE_PARSER, TYPESET(1));


### PR DESCRIPTION
By this fix, `DEFINE_PARSER(T)` macro no longer define function `SHOW(T)(R x)` but just declare. 
The function `SHOW(T)(R x) { /* print x; */ }` must be defined explicitly if it was not defined, 
when define a `PARSER(T)` class by `DEFINE_PARSER(T)` macro.